### PR TITLE
ignoring next 15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,5 @@ updates:
     ignore:
       - dependency-name: "next"
         versions: ["^15"]
+      - dependency-name: "next"
+        versions: ["^19"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,5 +25,5 @@ updates:
     ignore:
       - dependency-name: "next"
         versions: ["^15"]
-      - dependency-name: "next"
+      - dependency-name: "react"
         versions: ["^19"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,6 @@ updates:
       dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "next"
+        versions: ["^15"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,5 @@ updates:
         versions: ["^15"]
       - dependency-name: "react"
         versions: ["^19"]
+      - dependency-name: "react-dom"
+        versions: ["^19"]


### PR DESCRIPTION
Dependabot suggests updating to next 15, but this will cause compatibility issues as there's a bug with the app router. Until this is fixed, we should ignore it.