### PR TITLE
added react auth context

### DIFF
--- a/web/cypress/e2e/accessibility.cy.ts
+++ b/web/cypress/e2e/accessibility.cy.ts
@@ -1,23 +1,18 @@
 import "cypress-axe";
 
-describe("Accessibility - ARC Portal Homepage", () => {
-  it("should have no critical or serious accessibility violations on initial load", () => {
-    cy.visit("/");
+const pages = [
+  { name: "Homepage", path: "/" },
+  { name: "Profile page", path: "/profile" },
+];
 
-    cy.injectAxe();
-    cy.checkA11y(undefined, {
-      includedImpacts: ["critical", "serious"],
-    });
-  });
-});
-
-describe("Accessibility - ARC Portal Profile page", () => {
-  it("should have no critical or serious accessibility violations on initial load", () => {
-    cy.visit("/profile");
-
-    cy.injectAxe();
-    cy.checkA11y(undefined, {
-      includedImpacts: ["critical", "serious"],
+describe("Accessibility - ARC Portal", () => {
+  pages.forEach(({ name, path }) => {
+    it(`should have no critical or serious accessibility violations on ${name}`, () => {
+      cy.visit(path);
+      cy.injectAxe();
+      cy.checkA11y(undefined, {
+        includedImpacts: ["critical", "serious"],
+      });
     });
   });
 });

--- a/web/cypress/e2e/accessibility.cy.ts
+++ b/web/cypress/e2e/accessibility.cy.ts
@@ -10,3 +10,14 @@ describe("Accessibility - ARC Portal Homepage", () => {
     });
   });
 });
+
+describe("Accessibility - ARC Portal Profile page", () => {
+  it("should have no critical or serious accessibility violations on initial load", () => {
+    cy.visit("/profile");
+
+    cy.injectAxe();
+    cy.checkA11y(undefined, {
+      includedImpacts: ["critical", "serious"],
+    });
+  });
+});

--- a/web/cypress/e2e/app.cy.ts
+++ b/web/cypress/e2e/app.cy.ts
@@ -19,6 +19,6 @@ describe("ARC Portal UI authenticated", () => {
 
     cy.visit("/");
     cy.contains("Loading...").should("not.exist");
-    cy.contains("GET /profile").should("exist");
+    cy.contains("List of user tasks here").should("exist");
   });
 });

--- a/web/src/app/UserTasks.tsx
+++ b/web/src/app/UserTasks.tsx
@@ -1,17 +1,12 @@
 "use client";
 
 import { useAuth } from "./hooks/useAuth";
+import LoginFallback from "@/components/ui/LoginFallback";
 
 export default function UserTasks() {
   const { isAuthed, userData } = useAuth();
 
-  if (!isAuthed) {
-    return (
-      <a href={`/oauth2/start`} className="btn--login" id="login">
-        Login with UCL SSO
-      </a>
-    );
-  }
+  if (!isAuthed) return <LoginFallback />;
 
   return (
     <div className="card">

--- a/web/src/app/UserTasks.tsx
+++ b/web/src/app/UserTasks.tsx
@@ -3,13 +3,11 @@
 import { useAuth } from "./hooks/useAuth";
 
 export default function UserTasks() {
-  const { loading, isAuthed, userData } = useAuth();
-
-  if (loading) return <p>Loading…</p>;
+  const { isAuthed, userData } = useAuth();
 
   if (!isAuthed) {
     return (
-      <a href={`/oauth2/start?rd=${encodeURIComponent(window.location.pathname)}`} className="btn--login" id="login">
+      <a href={`/oauth2/start`} className="btn--login" id="login">
         Login with UCL SSO
       </a>
     );

--- a/web/src/app/UserTasks.tsx
+++ b/web/src/app/UserTasks.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useAuth } from "./hooks/useAuth";
+
+export default function UserTasks() {
+  const { loading, isAuthed, userData } = useAuth();
+
+  if (loading) return <p>Loading…</p>;
+
+  if (!isAuthed) {
+    return (
+      <a href={`/oauth2/start?rd=${encodeURIComponent(window.location.pathname)}`} className="btn--login" id="login">
+        Login with UCL SSO
+      </a>
+    );
+  }
+
+  return (
+    <div className="card">
+      <p>
+        Username&nbsp;{userData!.username}. Roles:&nbsp;
+        {userData!.roles.join(", ")}
+      </p>
+
+      <div>Your tasks:</div>
+      <div>List of user tasks here (e.g. approved researcher process)</div>
+    </div>
+  );
+}

--- a/web/src/app/hooks/useAuth.tsx
+++ b/web/src/app/hooks/useAuth.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+import { getProfile } from "@/openapi";
+import { ProfileResponse } from "@/openapi";
+
+type AuthCtxValue = {
+  loading: boolean;
+  isAuthed: boolean;
+  userData: ProfileResponse | null;
+};
+
+const AuthCtx = createContext<AuthCtxValue>({
+  loading: true,
+  isAuthed: false,
+  userData: null,
+});
+
+export const useAuth = () => useContext(AuthCtx);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [loading, setLoading] = useState(true);
+  const [isAuthed, setIsAuthed] = useState(false);
+  const [userData, setUserData] = useState<ProfileResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const checkAuth = async () => {
+      try {
+        const response = await getProfile();
+
+        if (!cancelled && response.response.status === 200 && response.data) {
+          setIsAuthed(true);
+          setUserData(response.data);
+        } else if (!cancelled) {
+          setIsAuthed(false);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          console.error("Profile fetch error:", err);
+          setIsAuthed(false);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    checkAuth();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return <AuthCtx.Provider value={{ loading, isAuthed, userData }}>{children}</AuthCtx.Provider>;
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,22 +1,24 @@
 import "./globals.css";
 import "./layout.css";
 
+import { AuthProvider } from "../app/hooks/useAuth";
 import Nav from "@/components/nav/Nav";
-import type { ReactNode } from "react";
 
 export const metadata = {
   title: "UCL ARC | portal",
   description: "Portal for UCL ARC services",
 };
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <div className="layout">
-          <Nav />
-          <main className="main-content">{children}</main>
-        </div>
+        <AuthProvider>
+          <div className="layout">
+            <Nav />
+            <main className="main-content">{children}</main>
+          </div>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,59 +1,17 @@
-"use client";
+import UserTasks from "./UserTasks";
 
-import { useEffect, useState } from "react";
-
-import "./page.css";
-
-import { getProfile } from "@/openapi";
+export const metadata = {
+  title: "ARC Services Portal | UCL",
+  description: "Login to access the ARC Services Portal.",
+};
 
 export default function Home() {
-  const [helloMessage, setHelloMessage] = useState<string>("");
-  const [isAuthed, setIsAuthed] = useState<boolean | undefined>(undefined);
-
-  useEffect(() => {
-    const fetchProfile = async () => {
-      try {
-        const response = await getProfile();
-
-        if (response.response.status === 200 && response.data) {
-          const { username, roles } = response.data;
-          setHelloMessage(`Username: ${username}. Roles: ${roles.join(", ")}`);
-          setIsAuthed(true);
-        } else {
-          setIsAuthed(false);
-        }
-      } catch (error) {
-        console.error("Failed to fetch profile:", error);
-        setIsAuthed(false);
-      }
-    };
-
-    fetchProfile();
-  }, []);
-
   return (
     <div className="page">
       <h1 id="title--portal">Welcome to the ARC Services Portal</h1>
+      <p>This portal allows UCL researchers to manage ARC services and tasks.</p>
 
-      {isAuthed === undefined && <p>Loading...</p>}
-
-      {isAuthed === false && (
-        <a href="/oauth2/start" className="btn--login" id="login" role="button">
-          Login with UCL SSO
-        </a>
-      )}
-
-      {isAuthed === true && (
-        <>
-          <div className="card">
-            <p id="confirmation--login">
-              GET /profile → <strong>{helloMessage}</strong>
-            </p>
-            <div>Your tasks:</div>
-            <div>List of user tasks here (e.g. approved researcher process)</div>
-          </div>
-        </>
-      )}
+      <UserTasks />
     </div>
   );
 }

--- a/web/src/app/profile/approved-researcher/components/AgreementText.tsx
+++ b/web/src/app/profile/approved-researcher/components/AgreementText.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getAgreementsApprovedResearcher } from "@/openapi";
+
+export default function AgreementText() {
+  const [agreementText, setAgreementText] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchAgreement = async () => {
+      try {
+        const res = await getAgreementsApprovedResearcher();
+
+        if (res.response.status === 200 && res.data) {
+          setAgreementText(res.data.text);
+        }
+      } catch (err) {
+        console.error("Agreement fetch error:", err);
+      }
+    };
+
+    fetchAgreement();
+  }, []);
+
+  return <p>{agreementText}</p>;
+}

--- a/web/src/app/profile/approved-researcher/components/ApprovedResearcher.tsx
+++ b/web/src/app/profile/approved-researcher/components/ApprovedResearcher.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useAuth } from "../../../hooks/useAuth";
+import ApprovedResearcherForm from "./ApprovedResearcherForm";
+import AgreementText from "./AgreementText";
+
+export default function ApprovedResearcher() {
+  const { loading, isAuthed } = useAuth();
+
+  if (loading) return <p>Loading…</p>;
+
+  if (!isAuthed) {
+    return (
+      <>
+        <p>You must be logged in to view this page</p>
+        <a href="/oauth2/start" className="btn--login" id="login" role="button">
+          Login with UCL SSO
+        </a>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <ApprovedResearcherForm />
+      <AgreementText />
+    </>
+  );
+}

--- a/web/src/app/profile/approved-researcher/components/ApprovedResearcher.tsx
+++ b/web/src/app/profile/approved-researcher/components/ApprovedResearcher.tsx
@@ -5,9 +5,7 @@ import ApprovedResearcherForm from "./ApprovedResearcherForm";
 import AgreementText from "./AgreementText";
 
 export default function ApprovedResearcher() {
-  const { loading, isAuthed } = useAuth();
-
-  if (loading) return <p>Loading…</p>;
+  const { isAuthed } = useAuth();
 
   if (!isAuthed) {
     return (

--- a/web/src/app/profile/approved-researcher/components/ApprovedResearcher.tsx
+++ b/web/src/app/profile/approved-researcher/components/ApprovedResearcher.tsx
@@ -1,22 +1,14 @@
 "use client";
 
 import { useAuth } from "../../../hooks/useAuth";
+import LoginFallback from "@/components/ui/LoginFallback";
 import ApprovedResearcherForm from "./ApprovedResearcherForm";
 import AgreementText from "./AgreementText";
 
 export default function ApprovedResearcher() {
   const { isAuthed } = useAuth();
 
-  if (!isAuthed) {
-    return (
-      <>
-        <p>You must be logged in to view this page</p>
-        <a href="/oauth2/start" className="btn--login" id="login" role="button">
-          Login with UCL SSO
-        </a>
-      </>
-    );
-  }
+  if (!isAuthed) return <LoginFallback />;
 
   return (
     <>

--- a/web/src/app/profile/approved-researcher/page.tsx
+++ b/web/src/app/profile/approved-researcher/page.tsx
@@ -1,55 +1,17 @@
-"use client";
+import ApprovedResearcher from "./components/ApprovedResearcher";
 
-import { useEffect, useState } from "react";
-import { getProfile } from "@/openapi";
+export const metadata = {
+  title: "Become an Approved Researcher | ARC Portal",
+  description: "Submit your application to become an approved researcher.",
+};
 
-import ApprovedResearcherForm from "./components/ApprovedResearcherForm";
-
-export default function ProfilePage() {
-  const [isAuthed, setIsAuthed] = useState<boolean | undefined>(undefined);
-  const [username, setUsername] = useState<string | null>(null);
-
-  useEffect(() => {
-    const checkAuth = async () => {
-      try {
-        const response = await getProfile();
-
-        if (response.response.status === 200 && response.data) {
-          setIsAuthed(true);
-          setUsername(response.data.username);
-        } else {
-          setIsAuthed(false);
-        }
-      } catch (err) {
-        console.error("Profile fetch error:", err);
-        setIsAuthed(false);
-      }
-    };
-
-    checkAuth();
-  }, []);
-
-  if (isAuthed === undefined) return <p>Loading...</p>;
-
-  if (!isAuthed) {
-    return (
-      <div className="profile-page">
-        <h1>Access Profile</h1>
-
-        <p>You must be logged in to view this page</p>
-
-        <a href="/oauth2/start" className="btn--login" id="login" role="button">
-          Login with UCL SSO
-        </a>
-      </div>
-    );
-  }
-
+export default function ApprovedResearcherPage() {
   return (
     <div className="profile-page">
-      <h1>Welcome, {username}!</h1>
+      <h1>Become an Approved Researcher</h1>
+      <p>To gain access to advanced services, please complete the following agreement.</p>
 
-      <ApprovedResearcherForm />
+      <ApprovedResearcher />
     </div>
   );
 }

--- a/web/src/app/profile/components/Profile.tsx
+++ b/web/src/app/profile/components/Profile.tsx
@@ -4,15 +4,13 @@ import Link from "next/link";
 import { useAuth } from "../../hooks/useAuth";
 
 export default function Profile() {
-  const { loading, isAuthed, userData } = useAuth();
-
-  if (loading) return <p>Loading…</p>;
+  const { isAuthed, userData } = useAuth();
 
   if (!isAuthed) {
     return (
       <>
         <p>You must be logged in to view this page</p>
-        <a href={`/oauth2/start?rd=${encodeURIComponent(window.location.pathname)}`} className="btn--login">
+        <a href={`/oauth2/start`} className="btn--login">
           Login with UCL SSO
         </a>
       </>

--- a/web/src/app/profile/components/Profile.tsx
+++ b/web/src/app/profile/components/Profile.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import { useAuth } from "../../hooks/useAuth";
+
+export default function Profile() {
+  const { loading, isAuthed, userData } = useAuth();
+
+  if (loading) return <p>Loading…</p>;
+
+  if (!isAuthed) {
+    return (
+      <>
+        <p>You must be logged in to view this page</p>
+        <a href={`/oauth2/start?rd=${encodeURIComponent(window.location.pathname)}`} className="btn--login">
+          Login with UCL SSO
+        </a>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h1>Welcome, {userData?.username}!</h1>
+
+      {!userData?.roles?.includes("approved-researcher") && (
+        <>
+          <p>
+            It looks like you are not yet an approved researcher. To get started, follow the link below to start the
+            approved researcher process.
+          </p>
+
+          <p>
+            <Link href="/profile/approved-researcher" className="btn--form">
+              Become an approved researcher
+            </Link>
+          </p>
+        </>
+      )}
+    </>
+  );
+}

--- a/web/src/app/profile/components/Profile.tsx
+++ b/web/src/app/profile/components/Profile.tsx
@@ -2,20 +2,12 @@
 
 import Link from "next/link";
 import { useAuth } from "../../hooks/useAuth";
+import LoginFallback from "@/components/ui/LoginFallback";
 
 export default function Profile() {
   const { isAuthed, userData } = useAuth();
 
-  if (!isAuthed) {
-    return (
-      <>
-        <p>You must be logged in to view this page</p>
-        <a href={`/oauth2/start`} className="btn--login">
-          Login with UCL SSO
-        </a>
-      </>
-    );
-  }
+  if (!isAuthed) return <LoginFallback />;
 
   return (
     <>

--- a/web/src/app/profile/page.tsx
+++ b/web/src/app/profile/page.tsx
@@ -1,67 +1,17 @@
-"use client";
+import Profile from "./components/Profile";
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-
-import { getProfile, ProfileResponse } from "@/openapi";
-
-import "./profile.css";
+export const metadata = {
+  title: "User Profile | ARC Services Portal",
+  description: "View and manage your ARC profile and researcher status.",
+};
 
 export default function ProfilePage() {
-  const [isAuthed, setIsAuthed] = useState<boolean | undefined>(undefined);
-  const [userData, setUserData] = useState<ProfileResponse | null>(null);
-
-  useEffect(() => {
-    const checkAuth = async () => {
-      try {
-        const response = await getProfile();
-
-        if (response.response.status === 200 && response.data) {
-          setIsAuthed(true);
-          setUserData(response.data);
-        } else {
-          setIsAuthed(false);
-        }
-      } catch (err) {
-        console.error("Profile fetch error:", err);
-        setIsAuthed(false);
-      }
-    };
-
-    checkAuth();
-  }, []);
-
-  if (isAuthed === undefined) return <p>Loading...</p>;
-
-  if (!isAuthed) {
-    return (
-      <div className="profile-page">
-        <h1>Access Profile</h1>
-
-        <p>You must be logged in to view this page</p>
-
-        <a href="/oauth2/start" className="btn--login" id="login" role="button">
-          Login with UCL SSO
-        </a>
-      </div>
-    );
-  }
-
   return (
     <div className="profile-page">
-      <h1>Welcome, {userData?.username}!</h1>
+      <h1>Profile</h1>
       <p>This is your profile. More profile features coming soon.</p>
 
-      {!userData?.roles?.includes("approved-researcher") && (
-        <p>
-          It looks like you are not yet an approved researcher. To get started, follow the link below to fill out the
-          form:
-          <Link href="/profile/approved-researcher" className="btn--form">
-            Approved Researcher Form
-          </Link>
-          .
-        </p>
-      )}
+      <Profile />
     </div>
   );
 }

--- a/web/src/components/ui/LoginFallback.css
+++ b/web/src/components/ui/LoginFallback.css
@@ -1,4 +1,4 @@
-.button {
+.login-link {
   font-size: 1.6rem;
   padding: 0.4rem;
 }

--- a/web/src/components/ui/LoginFallback.tsx
+++ b/web/src/components/ui/LoginFallback.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+export default function LoginFallback({
+  title = "Access Restricted",
+  message = "You must be logged in to view this page.",
+}: {
+  title?: string;
+  message?: string;
+}) {
+  return (
+    <>
+      <h1>{title}</h1>
+      <p>{message}</p>
+
+      <a href={`/oauth2/start?`} className="login-link" role="button">
+        Login with UCL SSO
+      </a>
+    </>
+  );
+}

--- a/web/src/components/ui/LoginFallback.tsx
+++ b/web/src/components/ui/LoginFallback.tsx
@@ -12,7 +12,7 @@ export default function LoginFallback({
       <h1>{title}</h1>
       <p>{message}</p>
 
-      <a href={`/oauth2/start?`} className="login-link" role="button">
+      <a href={`/oauth2/start?`} className="login-link" role="button" id="login">
         Login with UCL SSO
       </a>
     </>


### PR DESCRIPTION
## Resolves #65

- This PR adds a structure around the frontend auth flow.
- Specifically, it adds a React context and reusable Hook to detect the auth status on the frontend.
- The context uses the /profile endpoint to determine auth status. Then the context is consumed as and when it is needed on a component by component basis.

## An alternative approach
- You might ask whether the context approach is needed at all, since all api routes are protected anyway.
- However, I would argue that this approach makes the auth process clean and easy to keep track of (so more of a client convenience) and then we get the extra security from nginx that protects API routes directly.
- Still, if you really don't like the context approach, we could always default to something like this:

```
const fetchAgreement = async () => {
  try {
    const res = await getAgreementsApprovedResearcher();
    if (res.response.status === 200) setAgreementText(res.data.text);
    else if (res.response.status === 401) router.replace("/oauth2/start?..."); 
  } catch (e) { ... }
}
```
- This alternative approach wouldn't need a context, but we would have to repeat this logic in every route along with any state that is saved on a route by route basis.
- Let me know if you have any strong feelings one way or the other.

## Other bits

- I have also fleshed out the `profile` and `approved-researcher` page so we are now pulling in the agreement text. We can build on that in a follow-up PR.
- I have also laid out a reusable structure for static routes to maximise SEO. It goes like this:
    - Your page.tsx entrypoint should not be a `use client` component, this ensures the relevant HTML is baked into the page at buildtime
    - Then, any child components of page.tsx can be `use client` to take advantage of React features (e.g. state)

### Checklist

- [ ] Documentation has been updated
