### PR TITLE
preventing content flashes

### DIFF
--- a/web/src/app/UserTasks.tsx
+++ b/web/src/app/UserTasks.tsx
@@ -4,7 +4,9 @@ import { useAuth } from "./hooks/useAuth";
 import LoginFallback from "@/components/ui/LoginFallback";
 
 export default function UserTasks() {
-  const { isAuthed, userData } = useAuth();
+  const { loading, isAuthed, userData } = useAuth();
+
+  if (loading) return null;
 
   if (!isAuthed) return <LoginFallback />;
 

--- a/web/src/app/profile/approved-researcher/components/ApprovedResearcher.tsx
+++ b/web/src/app/profile/approved-researcher/components/ApprovedResearcher.tsx
@@ -6,7 +6,9 @@ import ApprovedResearcherForm from "./ApprovedResearcherForm";
 import AgreementText from "./AgreementText";
 
 export default function ApprovedResearcher() {
-  const { isAuthed } = useAuth();
+  const { loading, isAuthed } = useAuth();
+
+  if (loading) return null;
 
   if (!isAuthed) return <LoginFallback />;
 

--- a/web/src/app/profile/components/Profile.tsx
+++ b/web/src/app/profile/components/Profile.tsx
@@ -5,7 +5,9 @@ import { useAuth } from "../../hooks/useAuth";
 import LoginFallback from "@/components/ui/LoginFallback";
 
 export default function Profile() {
-  const { isAuthed, userData } = useAuth();
+  const { loading, isAuthed, userData } = useAuth();
+
+  if (loading) return null;
 
   if (!isAuthed) return <LoginFallback />;
 


### PR DESCRIPTION
## Resolves #67 

- Just a quick follow-up to improve the UI behaviour while the auth state is being loaded.
- The updated solution in this PR would default to showing no content until the auth state is finished loading, an alternative would be to show a message such as `loading..` or a spinner (but I don't think @t-young31 prefers that option)
- More context provided in #67 so feel free to post opinions on what your preferred solution would be

### Checklist

- [ ] Documentation has been updated
