### PR TITLE
moved waitForAPI command into login command

### DIFF
--- a/web/cypress/e2e/app.cy.ts
+++ b/web/cypress/e2e/app.cy.ts
@@ -1,7 +1,6 @@
 beforeEach(() => {
   cy.clearCookies();
   cy.clearLocalStorage();
-  cy.waitForApi(); // poll until the backend API is healthy
 });
 
 describe("ARC Portal UI unauthenticated", () => {

--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -71,6 +71,6 @@ Cypress.Commands.add("loginAsAdmin", () => {
     log.snapshot("after");
     log.end();
 
-    cy.waitForApi(); // Wait for the API to be available
+    cy.waitForApi(); // poll until the backend API is available
   });
 });

--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -70,5 +70,7 @@ Cypress.Commands.add("loginAsAdmin", () => {
 
     log.snapshot("after");
     log.end();
+
+    cy.waitForApi(); // Wait for the API to be available
   });
 });


### PR DESCRIPTION
## Resolves #78 

- This solution bakes the `waitForAPI` command into the `loginAsAdmin` command so that it will throw an error if it tries to do backend requests while the API is not ready.
- It's less modular, but prevents us from having to call the `waitForAPI` command in every test that needs backend interaction

### Checklist

- [ ] Documentation has been updated
