### PR TITLE
add base login

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,9 @@ jobs:
           cat <<EOF > web/cypress.env.json
           {
             "botAdminUsername": "portal-e2e-admin@arctretest.onmicrosoft.com",
-            "botAdminPassword": "${{ secrets.CYPRESS_BOT_ADMIN_PASSWORD }}"
+            "botAdminPassword": "${{ secrets.CYPRESS_BOT_ADMIN_PASSWORD }}",
+            "botBaseUsername": "portal-e2e-base@arctretest.onmicrosoft.com",
+            "botBasePassword": "${{ secrets.CYPRESS_BOT_BASE_PASSWORD }}"
           }
           EOF
 

--- a/internal/service/profile/attributes.go
+++ b/internal/service/profile/attributes.go
@@ -11,7 +11,7 @@ import (
 
 func (s *Service) Attributes(user types.User) (types.UserAttributes, error) {
 	attrs := types.UserAttributes{}
-	result := s.db.Find(&attrs).Limit(1).Where("user_id = ?", user.ID)
+	result := s.db.Find(&attrs, "user_id = ?", user.ID)
 	return attrs, result.Error
 }
 

--- a/web/cypress/e2e/app.cy.ts
+++ b/web/cypress/e2e/app.cy.ts
@@ -41,7 +41,7 @@ describe("ARC Portal UI authenticated", () => {
 
 describe("Setting chosen name for user", () => {
   beforeEach(() => {
-    cy.loginAsAdmin();
+    cy.loginAsBase();
     cy.clearChosenName();
     cy.visit("/");
   });

--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -4,6 +4,9 @@ import { login } from "./auth";
 
 const botAdminUsername = Cypress.env("botAdminUsername") as string;
 const botAdminPassword = Cypress.env("botAdminPassword") as string;
+const botBaseUsername = Cypress.env("botBaseUsername") as string;
+const botBasePassword = Cypress.env("botBasePassword") as string;
+
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Cypress {
@@ -13,6 +16,12 @@ declare global {
        * @example cy.loginAsAdmin()
        */
       loginAsAdmin(): Chainable<JQuery<HTMLElement>>;
+
+      /**
+       * Custom command to login as as as base user
+       * @example cy.loginAsBase()
+       */
+      loginAsBase(): Chainable<JQuery<HTMLElement>>;
 
       /**
        * Repeatedly polls the given endpoint until it answers with a status
@@ -65,7 +74,7 @@ Cypress.Commands.add("loginAsAdmin", () => {
   // See: https://docs.cypress.io/app/guides/authentication-testing/azure-active-directory-authentication
   cy.session(`login-admin`, () => {
     const log = Cypress.log({
-      displayName: "Entra ID Login",
+      displayName: "Entra ID Admin Login",
       message: [`🔐 Authenticating admin`],
       autoEnd: false,
     });
@@ -73,6 +82,23 @@ Cypress.Commands.add("loginAsAdmin", () => {
     log.snapshot("before");
     login(botAdminUsername, botAdminPassword);
 
+    log.snapshot("after");
+    log.end();
+
+    cy.waitForApi(); // poll until the backend API is available
+  });
+});
+
+Cypress.Commands.add("loginAsBase", () => {
+  cy.session(`login-base`, () => {
+    const log = Cypress.log({
+      displayName: "Entra ID Base user Login",
+      message: [`🔐 Authenticating base user`],
+      autoEnd: false,
+    });
+
+    log.snapshot("before");
+    login(botBaseUsername, botBasePassword);
     log.snapshot("after");
     log.end();
 


### PR DESCRIPTION
## Resolves #98 

- Adds a `loginAsBase` cypress command
- Fixes a bug in the name selection – tests are good!
- Adds the required password to the github environment (@acholyn / @jhughes982 please remind me tomorrow to make equivelant users for yourselves)


### Checklist

- n/a Documentation has been updated
