### PR TITLE
refactored accessibility tests

### DIFF
--- a/web/cypress/e2e/accessibility.cy.ts
+++ b/web/cypress/e2e/accessibility.cy.ts
@@ -6,15 +6,53 @@ const pages = [
   { name: "Studies page", path: "/studies" },
   { name: "Assets page", path: "/assets" },
   { name: "Projects page", path: "/projects" },
+  { name: "People page", path: "/people" },
 ];
 
 describe("Accessibility - ARC Portal", () => {
-  pages.forEach(({ name, path }) => {
-    it(`should have no critical or serious accessibility violations on ${name}`, () => {
-      cy.visit(path);
-      cy.injectAxe();
-      cy.checkA11y(undefined, {
-        includedImpacts: ["critical", "serious"],
+  describe("Unauthenticated content", () => {
+    pages.forEach(({ name, path }) => {
+      it(`should have no critical accessibility violations on ${name} (login fallback)`, () => {
+        cy.visit(path);
+        cy.get("header").should("be.visible"); // wait for page layout to load
+        cy.injectAxe();
+        cy.checkA11y(undefined, {
+          includedImpacts: ["critical", "serious"],
+        });
+      });
+    });
+  });
+
+  describe("Base user content", () => {
+    beforeEach(() => {
+      cy.loginAsBase();
+    });
+
+    pages.forEach(({ name, path }) => {
+      it(`should have no critical accessibility violations on ${name} (base user)`, () => {
+        cy.visit(path);
+        cy.get("header").should("be.visible"); // wait for page layout to load
+        cy.injectAxe();
+        cy.checkA11y(undefined, {
+          includedImpacts: ["critical", "serious"],
+        });
+      });
+    });
+  });
+
+  describe("Admin user content", () => {
+    beforeEach(() => {
+      cy.loginAsAdmin();
+    });
+
+    pages.forEach(({ name, path }) => {
+      it(`should have no critical accessibility violations on ${name} (admin user)`, () => {
+        cy.visit(path);
+        cy.get("header").should("be.visible"); // wait for page layout to load
+        cy.injectAxe();
+        cy.checkA11y(undefined, {
+          includedImpacts: ["critical", "serious"],
+        });
       });
     });
   });


### PR DESCRIPTION
## Resolves #125 

- This PR refactors the accessibility tests to make them actually test our app content,
- Up until now, the accessibility tests have silently not been working as intended because the tests have been running based on blank content (see the tagged issue for more context)
- So this PR offers a solution to making sure the accessibility tests are running against our app content.
- I have also added additional accessibility blocks, so now our accessibility tests will run against three conditions: unauthenticated, authenticated with base role, authenticated with admin role

## Note
- Now that the tests are actually running against our app content it has found legitimate accessibility test failures. 
- I will try to fix these myself, but may have to catch up with whoever wrote the original code if I run into any issues.

<!--
For example "Resolves #42" if this PR resolves issue 42
-->

### Checklist

- [ ] Documentation has been updated
