### PR TITLE
fix nhsd valid regex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN go install github.com/air-verse/air@latest
 
 WORKDIR /repo
 ENV GIN_MODE="debug"
-CMD ["air", "--build.cmd", "go build -o bin/api cmd/api/main.go", "--build.bin", "./bin/api", "--build.exclude_dir", "web,bin,deploy,tmp"]
+CMD ["air", "--build.cmd", "go build -o bin/api cmd/api/main.go", "--build.bin", "./bin/api", "--build.exclude_dir", "web,bin,deploy,tmp,e2e,docs"]
 
 # -------------------------------------------
 # Whole repo should be mounted in under /repo

--- a/internal/service/users/certificate/nhsd.go
+++ b/internal/service/users/certificate/nhsd.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	isValidPattern   = `This is to certify that.*completed the course Data Security Awareness`
+	isValidPattern   = `This is to certify that.*completed the (?:course|programme) Data Security Awareness`
 	issuedAtPattern  = `Data Security Awareness.*On\s*(\d{1,2} \w+ \d{4})`
 	firstNamePattern = `certify that[\s]*(\w+)`
 	lastNamePattern  = `certify that[\s]*\w+ (\w+)`

--- a/internal/service/users/certificate/nhsd_test.go
+++ b/internal/service/users/certificate/nhsd_test.go
@@ -30,6 +30,16 @@ func TestInvalidNHSDCertificateParse(t *testing.T) {
 	assert.False(t, certificate.IsValid)
 }
 
+func TestValidRegex(t *testing.T) {
+	validTexts := []string{
+		"This is to certify that Bob Smith completed the programme Data Security Awareness",
+		"This is to certify that Alice Taylor-Smith completed the course Data Security Awareness",
+	}
+	for _, text := range validTexts {
+		assert.True(t, isValidRegex.MatchString(text))
+	}
+}
+
 func mustBase64Encode(t *testing.T, filepath string) string {
 	content, err := os.ReadFile(filepath)
 	assert.NoError(t, err)

--- a/web/src/components/profile/approved-researcher/TrainingCertificate.tsx
+++ b/web/src/components/profile/approved-researcher/TrainingCertificate.tsx
@@ -105,7 +105,7 @@ export default function TrainingCertificate({ setTrainingCertificateCompleted }:
         setTrainingCertificateCompleted(true);
       }
     } catch (err) {
-      setErrorMessage(`Certificate upload failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+      setErrorMessage(`Certificate upload failed: ${err instanceof Error ? err.message : "Unknown error"}. `);
       setErrorType("error");
     } finally {
       setIsSubmitting(false);


### PR DESCRIPTION
Hotfix for parsing newer NHSD certificates

### Drive bys
- Adds a couple more exclusions to the air build
- Fixes the formatting of the error message on a failed training certificate fetch

### Checklist

- n/a Documentation has been updated
