### PR TITLE
entra controller refactor

### DIFF
--- a/internal/controller/entra/main.go
+++ b/internal/controller/entra/main.go
@@ -56,7 +56,7 @@ func New() *Controller {
 	return controller
 }
 
-func (c *Controller) UserData(ctx context.Context, username types.Username) (*UserData, error) {
+func (c *Controller) userData(ctx context.Context, username types.Username) (*UserData, error) {
 	if userData, exists := c.userDataCache.Get(username); exists {
 		return &userData, nil
 	}
@@ -81,7 +81,7 @@ func (c *Controller) IsStaffMember(ctx context.Context, username string) (bool, 
 		return false, fmt.Errorf("username cannot be empty")
 	}
 
-	userData, err := c.UserData(ctx, types.Username(username))
+	userData, err := c.userData(ctx, types.Username(username))
 	if err != nil {
 		return false, fmt.Errorf("username [%v] not found in directory", username)
 	}

--- a/internal/handler/web/auth.go
+++ b/internal/handler/web/auth.go
@@ -11,7 +11,7 @@ import (
 func (h *Handler) GetAuth(ctx *gin.Context) {
 	user := middleware.GetUser(ctx)
 
-	authInfo, err := h.auth.AuthInfo(ctx.Request.Context(), user)
+	authInfo, err := h.auth.AuthInfo(ctx, user)
 	if err != nil {
 		setError(ctx, err, "Failed to get auth info")
 		return

--- a/internal/service/auth/main.go
+++ b/internal/service/auth/main.go
@@ -27,7 +27,7 @@ func (s *Service) AuthInfo(ctx context.Context, user types.User) (*types.AuthInf
 		return nil, types.NewErrServerError(err)
 	}
 
-	isStaff, err := s.entra.IsStaffMember(ctx, string(user.Username))
+	isStaff, err := s.entra.IsStaffMember(ctx, user.Username)
 	if err != nil {
 		log.Warn().Err(err).Str("user", string(user.Username)).Msg("Failed to validate employee status")
 		isStaff = false // Default to false if there's an error

--- a/internal/service/auth/main.go
+++ b/internal/service/auth/main.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/ucl-arc-tre/portal/internal/controller/entra"
@@ -16,7 +15,7 @@ type Service struct {
 
 func New() *Service {
 	service := Service{
-		entra: entra.New(1 * time.Hour),
+		entra: entra.New(),
 	}
 	return &service
 }

--- a/internal/service/studies/main.go
+++ b/internal/service/studies/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/ucl-arc-tre/portal/internal/controller/entra"
@@ -26,7 +25,7 @@ type Service struct {
 func New() *Service {
 	return &Service{
 		db:    graceful.NewDB(),
-		entra: entra.New(1 * time.Hour),
+		entra: entra.New(),
 		users: users.New(),
 	}
 }

--- a/internal/service/studies/main.go
+++ b/internal/service/studies/main.go
@@ -31,7 +31,7 @@ func New() *Service {
 }
 
 // validate all study admin usernames and create/find corresponding users
-func (s *Service) validateAndCreateStudyAdmins(ctx context.Context, studyAdminUsernames []string) ([]types.User, error) {
+func (s *Service) validateAndCreateStudyAdmins(ctx context.Context, studyAdminUsernames []types.Username) ([]types.User, error) {
 	if len(studyAdminUsernames) == 0 {
 		return []types.User{}, nil
 	}
@@ -68,7 +68,7 @@ func (s *Service) validateAndCreateStudyAdmins(ctx context.Context, studyAdminUs
 	return studyAdminUsers, nil
 }
 
-func (s *Service) validateStudyData(ctx context.Context, username string, studyData openapi.StudyCreateRequest) error {
+func (s *Service) validateStudyData(ctx context.Context, username types.Username, studyData openapi.StudyCreateRequest) error {
 	titlePattern := regexp.MustCompile(`^\w[\w\s\-]{2,48}\w$`)
 	if !titlePattern.MatchString(studyData.Title) {
 		return errors.New("study title must be 4-50 characters, start and end with a letter/number, and contain only letters, numbers, spaces, and hyphens")
@@ -101,12 +101,16 @@ func (s *Service) validateStudyData(ctx context.Context, username string, studyD
 }
 
 func (s *Service) CreateStudy(ctx context.Context, user types.User, studyData openapi.StudyCreateRequest) (*types.Study, error) {
-	if err := s.validateStudyData(ctx, string(user.Username), studyData); err != nil {
+	if err := s.validateStudyData(ctx, user.Username, studyData); err != nil {
 		return nil, types.NewErrInvalidObject(err)
+	}
+	additionalStudyAdminUsernames := []types.Username{}
+	for _, username := range studyData.AdditionalStudyAdminUsernames {
+		additionalStudyAdminUsernames = append(additionalStudyAdminUsernames, types.Username(username))
 	}
 
 	// Validate and create study admin users if any are provided
-	studyAdminUsers, err := s.validateAndCreateStudyAdmins(ctx, studyData.AdditionalStudyAdminUsernames)
+	studyAdminUsers, err := s.validateAndCreateStudyAdmins(ctx, additionalStudyAdminUsernames)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/users/main.go
+++ b/internal/service/users/main.go
@@ -1,8 +1,6 @@
 package users
 
 import (
-	"time"
-
 	"github.com/ucl-arc-tre/portal/internal/controller/entra"
 	"github.com/ucl-arc-tre/portal/internal/graceful"
 	"gorm.io/gorm"
@@ -16,7 +14,7 @@ type Service struct {
 func New() *Service {
 	service := Service{
 		db:    graceful.NewDB(),
-		entra: entra.New(1 * time.Hour),
+		entra: entra.New(),
 	}
 	return &service
 }

--- a/internal/types/user.go
+++ b/internal/types/user.go
@@ -2,9 +2,9 @@ package types
 
 import "github.com/google/uuid"
 
-type Username string
+type Username string // e.g. ccxyz@ucl.ac.uk
 
-type ChosenName string
+type ChosenName string // e.g. Alice Smith
 
 type User struct {
 	Model


### PR DESCRIPTION
I noticed in the logs while debugging staging that there are already 4 entra controllers created, which as we're using a local rather than distributed cache, is less efficient that it could be.  This PR

-  Converts the entra controller into a singleton
- Bumps the cache TTL (thoughts welcomed on the value)
- Drive by: uses the inbuilt `Username` type where appropriate

### Checklist

- n/a Documentation has been updated
