### PR TITLE
added usecallback to auth hook

### DIFF
--- a/web/src/components/profile/ProfileSetup.tsx
+++ b/web/src/components/profile/ProfileSetup.tsx
@@ -44,7 +44,7 @@ export default function ProfileSetup(props: Props) {
     if (profileStepsCompleted) {
       refreshAuth();
     }
-  }, [profileStepsCompleted]);
+  }, [profileStepsCompleted, refreshAuth]);
 
   const profileSetupSteps: Step[] = [
     {

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { getAuth } from "@/openapi";
 import { Auth } from "@/openapi";
 
@@ -24,7 +24,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [userData, setUserData] = useState<Auth | null>(null);
 
   const cancelled = useRef(false);
-  const refreshAuth = async () => {
+
+  const refreshAuth = useCallback(async () => {
     try {
       const response = await getAuth();
 
@@ -42,7 +43,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     } finally {
       if (!cancelled.current) setAuthInProgress(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     refreshAuth();


### PR DESCRIPTION
## Resolves #242 

- This PR adds a useCallback to the auth hook.
- This means we can satisfy the linter while also avoiding the infinite loop situation
- For reference: the useCallback memoizes the function so React returns the same function reference between renders. So what was happening before is that new function references were being made on each render which is what triggered the infinite loop because it was added to the dependency array.
- I would suggest you test this out yourself to sanity check that it works. I did test it on my end but would feel better with another sign-off. 

<!--
For example "Resolves #42" if this PR resolves issue 42
-->

### Checklist

- [ ] Documentation has been updated
