### PR TITLE
fix logout redirect url

### DIFF
--- a/deploy/dev/oauth2-proxy.sample.cfg
+++ b/deploy/dev/oauth2-proxy.sample.cfg
@@ -16,6 +16,7 @@ oidc_issuer_url = "https://login.microsoftonline.com/<CHANGE_ME>/v2.0"
 client_secret = "<CHANGE_ME>"
 
 redirect_url = "http://localhost:8000/oauth2/callback"
+whitelist_domains = ["login.microsoftonline.com"]
 http_address="0.0.0.0:8080"
 email_domains=["*"]
 cookie_secure="false"

--- a/internal/handler/web/main.go
+++ b/internal/handler/web/main.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
@@ -31,7 +32,11 @@ func New() *Handler {
 
 func (h *Handler) GetLogout(ctx *gin.Context) {
 
-	logoutUrl := "/oauth2/sign_out?rd=https://login.microsoftonline.com/" + config.EntraCredentials().TenantID + "/oauth2/v2.0/logout?post_logout_redirect_uri=" + config.EntraInviteRedirectURL()
-
-	ctx.Redirect(http.StatusFound, logoutUrl)
+	redirectQuery := url.QueryEscape(
+		"https://login.microsoftonline.com/" +
+			config.EntraCredentials().TenantID +
+			"/oauth2/v2.0/logout?post_logout_redirect_uri=" +
+			config.EntraInviteRedirectURL(),
+	)
+	ctx.Redirect(http.StatusFound, "/oauth2/sign_out?rd="+redirectQuery)
 }


### PR DESCRIPTION
## Resolves #282

- Redirect url needs to be query escaped and the redirect domain whitelisted. See: https://oauth2-proxy.github.io/oauth2-proxy/features/endpoints#sign-out

### Checklist

- n/a Documentation has been updated
