### PR TITLE
set frame-ancestors, base-uri, form-action in CSP header

### DIFF
--- a/internal/middleware/secure.go
+++ b/internal/middleware/secure.go
@@ -21,7 +21,7 @@ func NewSecure() gin.HandlerFunc {
 		FrameDeny:             true,
 		ContentTypeNosniff:    true,
 		BrowserXssFilter:      true,
-		ContentSecurityPolicy: "default-src 'self'; style-src 'self' 'unsafe-inline';",
+		ContentSecurityPolicy: "default-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';",
 		IENoOpen:              true,
 		SSLProxyHeaders:       map[string]string{"X-Forwarded-Proto": "https"},
 	})


### PR DESCRIPTION
## Resolves #301

found when doing a bit of testing using [ZAP](https://www.zaproxy.org)

Medium | CSP: Failure to Define Directive with No Fallback
-- | --
Description | The Content Security Policy fails to define one of the directives that has no fallback. Missing/excluding them is the same as allowing anything.

docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy#directives

not tested this in an environment which sets the header, but should be fine

### Checklist

- n/a Documentation has been updated
