### PR TITLE
added temp asset migration and removed old migration

### DIFF
--- a/internal/graceful/db.go
+++ b/internal/graceful/db.go
@@ -1,7 +1,6 @@
 package graceful
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -34,7 +33,8 @@ func InitDB() {
 	db := NewDB()
 	db.Exec(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`)
 
-	migrateAssetTable(db)
+	// temporary migration of legal_basis data (remove once completed)
+	migrateLegalBasisData(db)
 
 	for _, t := range models {
 		if err := db.AutoMigrate(t); err != nil {
@@ -44,30 +44,31 @@ func InitDB() {
 	log.Debug().Msg("Initalised database")
 }
 
-// run the custom migration for the Asset table schema changes
-func migrateAssetTable(db *gorm.DB) {
-	log.Debug().Msg("Starting custom migration")
+// migrate existing free text legal_basis values to enum values
+func migrateLegalBasisData(db *gorm.DB) {
+	log.Debug().Msg("Starting legal_basis data migration")
 
-	if db.Migrator().HasTable(&types.Asset{}) {
-		log.Debug().Msg("Starting custom Asset table migration")
-
-		// Drop columns
-		if db.Migrator().HasColumn(&types.Asset{}, "expiry") {
-			if err := db.Migrator().DropColumn(&types.Asset{}, "expiry"); err != nil {
-				panic(fmt.Sprintf("Failed to drop expiry column: %v", err))
-			}
-		}
-		if db.Migrator().HasColumn(&types.Asset{}, "accessed_by_third_parties") {
-			if err := db.Migrator().DropColumn(&types.Asset{}, "accessed_by_third_parties"); err != nil {
-				panic(fmt.Sprintf("Failed to drop accessed_by_third_parties column: %v", err))
-			}
-		}
-		if db.Migrator().HasColumn(&types.Asset{}, "third_party_agreement") {
-			if err := db.Migrator().DropColumn(&types.Asset{}, "third_party_agreement"); err != nil {
-				panic(fmt.Sprintf("Failed to drop third_party_agreement column: %v", err))
-			}
-		}
+	// Update "A task in the public interest" to "public_task"
+	result := db.Model(&types.Asset{}).
+		Where("legal_basis = ?", "A task in the public interest").
+		Update("legal_basis", "public_task")
+	if result.Error != nil {
+		log.Error().Err(result.Error).Msg("Failed to migrate legal_basis: 'A task in the public interest'")
+	} else if result.RowsAffected > 0 {
+		log.Info().Int64("rows", result.RowsAffected).Msg("Migrated legal_basis: 'A task in the public interest' -> 'public_task'")
 	}
+
+	// Update "Public task" to "public_task"
+	result = db.Model(&types.Asset{}).
+		Where("legal_basis = ?", "Public task").
+		Update("legal_basis", "public_task")
+	if result.Error != nil {
+		log.Error().Err(result.Error).Msg("Failed to migrate legal_basis: 'Public task'")
+	} else if result.RowsAffected > 0 {
+		log.Info().Int64("rows", result.RowsAffected).Msg("Migrated legal_basis: 'Public task' -> 'public_task'")
+	}
+
+	log.Debug().Msg("Completed legal_basis data migration")
 }
 
 // Create a new gorm DB, blocking until a connection is made


### PR DESCRIPTION
## works towards #318 

- This PR adds the migration code as described in the linked ticket
- Two data rows will be affected, and the code specifically targets the known data entries that we want to change
- There was some old migration code from a few months ago that I think is also now safe to delete.

<!--
For example "Resolves #42" if this PR resolves issue 42
-->

### Checklist

- [ ] Documentation has been updated
