### PR TITLE
moving methods into their own files

### DIFF
--- a/internal/handler/web/assets.go
+++ b/internal/handler/web/assets.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ucl-arc-tre/portal/internal/types"
 )
 
+// Helper functions
+
 func assetToOpenApiAsset(asset types.Asset) openapi.Asset {
 	return openapi.Asset{
 		Id:                   asset.ID.String(),
@@ -32,6 +34,8 @@ func assetToOpenApiAsset(asset types.Asset) openapi.Asset {
 		UpdatedAt:            asset.UpdatedAt.Format(config.TimeFormat),
 	}
 }
+
+// Handler methods
 
 func (h *Handler) GetStudiesStudyIdAssets(ctx *gin.Context, studyId string) {
 	studyUUID, err := parseUUIDOrSetError(ctx, studyId)

--- a/internal/handler/web/contracts.go
+++ b/internal/handler/web/contracts.go
@@ -1,0 +1,228 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+	"github.com/ucl-arc-tre/portal/internal/config"
+	"github.com/ucl-arc-tre/portal/internal/middleware"
+	openapi "github.com/ucl-arc-tre/portal/internal/openapi/web"
+	"github.com/ucl-arc-tre/portal/internal/types"
+	"github.com/ucl-arc-tre/portal/internal/validation"
+)
+
+// Helper functions
+
+func mustParseDate(dateStr string) time.Time {
+	parsedDate, err := time.Parse(config.DateFormat, dateStr)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse date %q: %v", dateStr, err))
+	}
+	return parsedDate
+}
+
+func extractContractFormData(ctx *gin.Context) openapi.ContractUploadObject {
+	return openapi.ContractUploadObject{
+		OrganisationSignatory: ctx.PostForm("organisation_signatory"),
+		ThirdPartyName:        ctx.PostForm("third_party_name"),
+		Status:                openapi.ContractUploadObjectStatus(ctx.PostForm("status")),
+		StartDate:             ctx.PostForm("start_date"),
+		ExpiryDate:            ctx.PostForm("expiry_date"),
+	}
+}
+
+func contractToOpenApiContract(contract types.Contract) openapi.Contract {
+	return openapi.Contract{
+		Id:                    contract.ID.String(),
+		Filename:              contract.Filename,
+		OrganisationSignatory: contract.OrganisationSignatory,
+		ThirdPartyName:        contract.ThirdPartyName,
+		Status:                openapi.ContractStatus(contract.Status),
+		StartDate:             contract.StartDate.Format(config.DateFormat),
+		ExpiryDate:            contract.ExpiryDate.Format(config.DateFormat),
+		CreatedAt:             contract.CreatedAt.Format(config.TimeFormat),
+		UpdatedAt:             contract.UpdatedAt.Format(config.TimeFormat),
+	}
+}
+
+// Handler methods
+
+func (h *Handler) PostStudiesStudyIdAssetsAssetIdContractsUpload(ctx *gin.Context, studyId string, assetId string) {
+	uuids, err := parseUUIDsOrSetError(ctx, studyId, assetId)
+	if err != nil {
+		return
+	}
+
+	// Get the uploaded file
+	fileHeader, err := ctx.FormFile("file")
+	if err != nil {
+		setError(ctx, types.NewErrInvalidObject(err), "Failed to get uploaded file")
+		return
+	}
+
+	contractMetadata := extractContractFormData(ctx)
+
+	validationError := h.studies.ValidateContractMetadata(contractMetadata, fileHeader.Filename)
+	if validationError != nil {
+		ctx.JSON(http.StatusBadRequest, *validationError)
+		return
+	}
+
+	user := middleware.GetUser(ctx)
+
+	// Open the uploaded file
+	file, err := fileHeader.Open()
+	if err != nil {
+		setError(ctx, types.NewErrServerError(err), "Failed to open uploaded file")
+		return
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Error().Err(err).Msg("Failed to close uploaded file")
+		}
+	}()
+
+	if mimeType, err := validation.MimeType(file); err != nil {
+		setError(ctx, err, "Failed to determine MIME type of file")
+		return
+	} else if mimeType != types.MimeTypePdf {
+		setError(ctx, types.NewErrInvalidObject(fmt.Errorf("mime type was [%v] not PDF", mimeType)), "Invalid MIME type")
+		return
+	}
+
+	// Create the final contract record for storage
+	contractData := types.Contract{
+		AssetID:               uuids[1],
+		Filename:              fileHeader.Filename,
+		CreatorUserID:         user.ID,
+		OrganisationSignatory: contractMetadata.OrganisationSignatory,
+		ThirdPartyName:        contractMetadata.ThirdPartyName,
+		Status:                string(contractMetadata.Status),
+		StartDate:             mustParseDate(contractMetadata.StartDate),
+		ExpiryDate:            mustParseDate(contractMetadata.ExpiryDate),
+	}
+
+	contractObj := types.S3Object{
+		Content: file,
+	}
+	err = h.studies.StoreContract(ctx, uuids[0], contractObj, contractData)
+	if err != nil {
+		setError(ctx, err, "Failed to store contract")
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+func (h *Handler) PutStudiesStudyIdAssetsAssetIdContractsContractId(ctx *gin.Context, studyId string, assetId string, contractId string) {
+	uuids, err := parseUUIDsOrSetError(ctx, studyId, assetId, contractId)
+	if err != nil {
+		return
+	}
+
+	// Get optional uploaded file (don't error if no file provided)
+	fileHeader, _ := ctx.FormFile("file")
+	filename := ""
+	if fileHeader != nil {
+		filename = fileHeader.Filename
+	}
+
+	contractMetadata := extractContractFormData(ctx)
+
+	validationError := h.studies.ValidateContractMetadata(contractMetadata, filename)
+	if validationError != nil {
+		ctx.JSON(http.StatusBadRequest, *validationError)
+		return
+	}
+
+	// Handle file processing if a new file is provided
+	var contractObj *types.S3Object
+	if fileHeader != nil {
+		file, err := fileHeader.Open()
+		if err != nil {
+			setError(ctx, types.NewErrServerError(err), "Failed to open uploaded file")
+			return
+		}
+		defer func() {
+			if err := file.Close(); err != nil {
+				log.Error().Err(err).Msg("Failed to close uploaded file")
+			}
+		}()
+
+		if mimeType, err := validation.MimeType(file); err != nil {
+			setError(ctx, err, "Failed to determine MIME type of file")
+			return
+		} else if mimeType != types.MimeTypePdf {
+			setError(ctx, types.NewErrInvalidObject(fmt.Errorf("mime type was [%v] not PDF", mimeType)), "Invalid MIME type")
+			return
+		}
+
+		contractObj = &types.S3Object{
+			Content: file,
+		}
+	}
+
+	contractUpdateData := types.Contract{
+		ModelAuditable:        types.ModelAuditable{Model: types.Model{ID: uuids[2]}},
+		AssetID:               uuids[1],
+		OrganisationSignatory: contractMetadata.OrganisationSignatory,
+		ThirdPartyName:        contractMetadata.ThirdPartyName,
+		Status:                string(contractMetadata.Status),
+		StartDate:             mustParseDate(contractMetadata.StartDate),
+		ExpiryDate:            mustParseDate(contractMetadata.ExpiryDate),
+		Filename:              filename,
+	}
+
+	err = h.studies.UpdateContract(ctx, uuids[0], uuids[2], contractUpdateData, contractObj)
+	if err != nil {
+		setError(ctx, err, "Failed to update contract")
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+func (h *Handler) GetStudiesStudyIdAssetsAssetIdContracts(ctx *gin.Context, studyId string, assetId string) {
+	uuids, err := parseUUIDsOrSetError(ctx, studyId, assetId)
+	if err != nil {
+		return
+	}
+
+	contracts, err := h.studies.AssetContracts(uuids[0], uuids[1])
+	if err != nil {
+		setError(ctx, err, "Failed to retrieve contracts")
+		return
+	}
+
+	apiContracts := []openapi.Contract{}
+	for _, contract := range contracts {
+		apiContracts = append(apiContracts, contractToOpenApiContract(contract))
+	}
+	ctx.JSON(http.StatusOK, apiContracts)
+}
+
+func (h *Handler) GetStudiesStudyIdAssetsAssetIdContractsContractIdDownload(ctx *gin.Context, studyId string, assetId string, contractId string) {
+	uuids, err := parseUUIDsOrSetError(ctx, studyId, assetId, contractId)
+	if err != nil {
+		return
+	}
+	object, err := h.studies.GetContract(ctx, uuids[0], uuids[1], uuids[2])
+	if err != nil {
+		setError(ctx, err, "Failed get contract")
+		return
+	} else if object.NumBytes == nil {
+		setError(ctx, types.NewErrServerError("contract object missing content length"), "Failed get contract")
+		return
+	}
+	ctx.DataFromReader(
+		http.StatusOK,
+		*object.NumBytes,
+		"application/pdf",
+		object.Content, map[string]string{
+			"Content-Disposition": "attachment",
+		},
+	)
+}

--- a/internal/handler/web/studies.go
+++ b/internal/handler/web/studies.go
@@ -4,36 +4,14 @@ import (
 	"fmt"
 	"net/http"
 
-	"time"
-
 	"github.com/gin-gonic/gin"
-	"github.com/rs/zerolog/log"
 	"github.com/ucl-arc-tre/portal/internal/config"
 	"github.com/ucl-arc-tre/portal/internal/middleware"
 	openapi "github.com/ucl-arc-tre/portal/internal/openapi/web"
 	"github.com/ucl-arc-tre/portal/internal/rbac"
 	"github.com/ucl-arc-tre/portal/internal/service/agreements"
 	"github.com/ucl-arc-tre/portal/internal/types"
-	"github.com/ucl-arc-tre/portal/internal/validation"
 )
-
-func mustParseDate(dateStr string) time.Time {
-	parsedDate, err := time.Parse(config.DateFormat, dateStr)
-	if err != nil {
-		panic(fmt.Sprintf("failed to parse date %q: %v", dateStr, err))
-	}
-	return parsedDate
-}
-
-func extractContractFormData(ctx *gin.Context) openapi.ContractUploadObject {
-	return openapi.ContractUploadObject{
-		OrganisationSignatory: ctx.PostForm("organisation_signatory"),
-		ThirdPartyName:        ctx.PostForm("third_party_name"),
-		Status:                openapi.ContractUploadObjectStatus(ctx.PostForm("status")),
-		StartDate:             ctx.PostForm("start_date"),
-		ExpiryDate:            ctx.PostForm("expiry_date"),
-	}
-}
 
 func studyToOpenApiStudy(study types.Study) openapi.Study {
 	ownerUserIDStr := study.OwnerUserID.String()
@@ -69,20 +47,6 @@ func studyToOpenApiStudy(study types.Study) openapi.Study {
 		Feedback:                         study.Feedback,
 		CreatedAt:                        study.CreatedAt.Format(config.TimeFormat),
 		UpdatedAt:                        study.UpdatedAt.Format(config.TimeFormat),
-	}
-}
-
-func contractToOpenApiContract(contract types.Contract) openapi.Contract {
-	return openapi.Contract{
-		Id:                    contract.ID.String(),
-		Filename:              contract.Filename,
-		OrganisationSignatory: contract.OrganisationSignatory,
-		ThirdPartyName:        contract.ThirdPartyName,
-		Status:                openapi.ContractStatus(contract.Status),
-		StartDate:             contract.StartDate.Format(config.DateFormat),
-		ExpiryDate:            contract.ExpiryDate.Format(config.DateFormat),
-		CreatedAt:             contract.CreatedAt.Format(config.TimeFormat),
-		UpdatedAt:             contract.UpdatedAt.Format(config.TimeFormat),
 	}
 }
 
@@ -245,183 +209,6 @@ func (h *Handler) GetStudiesStudyIdAgreements(ctx *gin.Context, studyId string) 
 	ctx.JSON(http.StatusOK, studyAgreements)
 }
 
-func (h *Handler) PostStudiesStudyIdAssetsAssetIdContractsUpload(ctx *gin.Context, studyId string, assetId string) {
-	uuids, err := parseUUIDsOrSetError(ctx, studyId, assetId)
-	if err != nil {
-		return
-	}
-
-	// Get the uploaded file
-	fileHeader, err := ctx.FormFile("file")
-	if err != nil {
-		setError(ctx, types.NewErrInvalidObject(err), "Failed to get uploaded file")
-		return
-	}
-
-	contractMetadata := extractContractFormData(ctx)
-
-	validationError := h.studies.ValidateContractMetadata(contractMetadata, fileHeader.Filename)
-	if validationError != nil {
-		ctx.JSON(http.StatusBadRequest, *validationError)
-		return
-	}
-
-	user := middleware.GetUser(ctx)
-
-	// Open the uploaded file
-	file, err := fileHeader.Open()
-	if err != nil {
-		setError(ctx, types.NewErrServerError(err), "Failed to open uploaded file")
-		return
-	}
-	defer func() {
-		if err := file.Close(); err != nil {
-			log.Error().Err(err).Msg("Failed to close uploaded file")
-		}
-	}()
-
-	if mimeType, err := validation.MimeType(file); err != nil {
-		setError(ctx, err, "Failed to determine MIME type of file")
-		return
-	} else if mimeType != types.MimeTypePdf {
-		setError(ctx, types.NewErrInvalidObject(fmt.Errorf("mime type was [%v] not PDF", mimeType)), "Invalid MIME type")
-		return
-	}
-
-	// Create the final contract record for storage
-	contractData := types.Contract{
-		AssetID:               uuids[1],
-		Filename:              fileHeader.Filename,
-		CreatorUserID:         user.ID,
-		OrganisationSignatory: contractMetadata.OrganisationSignatory,
-		ThirdPartyName:        contractMetadata.ThirdPartyName,
-		Status:                string(contractMetadata.Status),
-		StartDate:             mustParseDate(contractMetadata.StartDate),
-		ExpiryDate:            mustParseDate(contractMetadata.ExpiryDate),
-	}
-
-	contractObj := types.S3Object{
-		Content: file,
-	}
-	err = h.studies.StoreContract(ctx, uuids[0], contractObj, contractData)
-	if err != nil {
-		setError(ctx, err, "Failed to store contract")
-		return
-	}
-
-	ctx.Status(http.StatusNoContent)
-}
-
-func (h *Handler) PutStudiesStudyIdAssetsAssetIdContractsContractId(ctx *gin.Context, studyId string, assetId string, contractId string) {
-	uuids, err := parseUUIDsOrSetError(ctx, studyId, assetId, contractId)
-	if err != nil {
-		return
-	}
-
-	// Get optional uploaded file (don't error if no file provided)
-	fileHeader, _ := ctx.FormFile("file")
-	filename := ""
-	if fileHeader != nil {
-		filename = fileHeader.Filename
-	}
-
-	contractMetadata := extractContractFormData(ctx)
-
-	validationError := h.studies.ValidateContractMetadata(contractMetadata, filename)
-	if validationError != nil {
-		ctx.JSON(http.StatusBadRequest, *validationError)
-		return
-	}
-
-	// Handle file processing if a new file is provided
-	var contractObj *types.S3Object
-	if fileHeader != nil {
-		file, err := fileHeader.Open()
-		if err != nil {
-			setError(ctx, types.NewErrServerError(err), "Failed to open uploaded file")
-			return
-		}
-		defer func() {
-			if err := file.Close(); err != nil {
-				log.Error().Err(err).Msg("Failed to close uploaded file")
-			}
-		}()
-
-		if mimeType, err := validation.MimeType(file); err != nil {
-			setError(ctx, err, "Failed to determine MIME type of file")
-			return
-		} else if mimeType != types.MimeTypePdf {
-			setError(ctx, types.NewErrInvalidObject(fmt.Errorf("mime type was [%v] not PDF", mimeType)), "Invalid MIME type")
-			return
-		}
-
-		contractObj = &types.S3Object{
-			Content: file,
-		}
-	}
-
-	contractUpdateData := types.Contract{
-		ModelAuditable:        types.ModelAuditable{Model: types.Model{ID: uuids[2]}},
-		AssetID:               uuids[1],
-		OrganisationSignatory: contractMetadata.OrganisationSignatory,
-		ThirdPartyName:        contractMetadata.ThirdPartyName,
-		Status:                string(contractMetadata.Status),
-		StartDate:             mustParseDate(contractMetadata.StartDate),
-		ExpiryDate:            mustParseDate(contractMetadata.ExpiryDate),
-		Filename:              filename,
-	}
-
-	err = h.studies.UpdateContract(ctx, uuids[0], uuids[2], contractUpdateData, contractObj)
-	if err != nil {
-		setError(ctx, err, "Failed to update contract")
-		return
-	}
-
-	ctx.Status(http.StatusNoContent)
-}
-
-func (h *Handler) GetStudiesStudyIdAssetsAssetIdContracts(ctx *gin.Context, studyId string, assetId string) {
-	uuids, err := parseUUIDsOrSetError(ctx, studyId, assetId)
-	if err != nil {
-		return
-	}
-
-	contracts, err := h.studies.AssetContracts(uuids[0], uuids[1])
-	if err != nil {
-		setError(ctx, err, "Failed to retrieve contracts")
-		return
-	}
-
-	apiContracts := []openapi.Contract{}
-	for _, contract := range contracts {
-		apiContracts = append(apiContracts, contractToOpenApiContract(contract))
-	}
-	ctx.JSON(http.StatusOK, apiContracts)
-}
-
-func (h *Handler) GetStudiesStudyIdAssetsAssetIdContractsContractIdDownload(ctx *gin.Context, studyId string, assetId string, contractId string) {
-	uuids, err := parseUUIDsOrSetError(ctx, studyId, assetId, contractId)
-	if err != nil {
-		return
-	}
-	object, err := h.studies.GetContract(ctx, uuids[0], uuids[1], uuids[2])
-	if err != nil {
-		setError(ctx, err, "Failed get contract")
-		return
-	} else if object.NumBytes == nil {
-		setError(ctx, types.NewErrServerError("contract object missing content length"), "Failed get contract")
-		return
-	}
-	ctx.DataFromReader(
-		http.StatusOK,
-		*object.NumBytes,
-		"application/pdf",
-		object.Content, map[string]string{
-			"Content-Disposition": "attachment",
-		},
-	)
-}
-
 func (h *Handler) PostStudiesAdminStudyIdReview(ctx *gin.Context, studyId string) {
 	review := openapi.StudyReview{}
 	if err := bindJSONOrSetError(ctx, &review); err != nil {
@@ -447,6 +234,7 @@ func (h *Handler) PostStudiesAdminStudyIdReview(ctx *gin.Context, studyId string
 
 	ctx.Status(http.StatusOK)
 }
+
 func (h *Handler) PatchStudiesStudyIdPending(ctx *gin.Context, studyId string) {
 	review := openapi.StudyReview{
 		Status: openapi.Pending,


### PR DESCRIPTION
- A quick housekeeping PR related to #427 
- This PR moves the asset related handler methods into `assets.go`
- Based on a [previous discussion](https://github.com/ucl-arc-tre/portal/pull/414#discussion_r2606890541)
- Opening as draft for now to get feedback. Does this feel tidier to everyone? If so, I could also move contract-related methods into its own `contracts.go` file to make `studies.go` a bit leaner.

If we feel this is not needed, happy to close.

<!--
For example "Resolves #42" if this PR resolves issue 42
-->

### Checklist

- [ ] Documentation has been updated
