### PR TITLE
removing project edit button for tre ops staff

### DIFF
--- a/api.web.yaml
+++ b/api.web.yaml
@@ -931,6 +931,10 @@ components:
           type: string
         roles:
           type: array
+          description: |
+            List of roles assigned to the user. This array can contain both:
+            - Global roles (see below enum values): System-wide roles like admin, staff, approved-researcher
+            - Additional dynamic resource-specific roles: Runtime roles like project_{id}_owner, study_{id}_admin
           items:
             type: string
             enum:

--- a/internal/openapi/web/main.gen.go
+++ b/internal/openapi/web/main.gen.go
@@ -308,6 +308,9 @@ type AssetBaseStatus string
 
 // Auth defines model for Auth.
 type Auth struct {
+	// Roles List of roles assigned to the user. This array can contain both:
+	// - Global roles (see below enum values): System-wide roles like admin, staff, approved-researcher
+	// - Additional dynamic resource-specific roles: Runtime roles like project_{id}_owner, study_{id}_admin
 	Roles    []AuthRoles `json:"roles"`
 	Username string      `json:"username"`
 }

--- a/web/src/openapi/types.gen.ts
+++ b/web/src/openapi/types.gen.ts
@@ -6,6 +6,12 @@ export type ClientOptions = {
 
 export type Auth = {
     username: string;
+    /**
+     * List of roles assigned to the user. This array can contain both:
+     * - Global roles (see below enum values): System-wide roles like admin, staff, approved-researcher
+     * - Additional dynamic resource-specific roles: Runtime roles like project_{id}_owner, study_{id}_admin
+     *
+     */
     roles: Array<'admin' | 'base' | 'staff' | 'approved-researcher' | 'approved-staff-researcher' | 'information-asset-owner' | 'information-asset-administrator' | 'tre-ops-staff' | 'ig-ops-staff'>;
 };
 

--- a/web/src/pages/projects/manage.tsx
+++ b/web/src/pages/projects/manage.tsx
@@ -35,7 +35,7 @@ export default function ManageProjectPage() {
   const isAdmin = userData?.roles.includes("admin");
   const isTreOpsStaff = userData?.roles.includes("tre-ops-staff");
   const canApprove = isAdmin || isTreOpsStaff;
-  const canEdit = userData?.roles.includes(`project_${projectId}_owner`);
+  const canEdit = (userData?.roles as string[]).includes(`project_${projectId}_owner`);
 
   // prepare the approved study for edit form
   const approvedStudy = project ? [{ id: project.study_id, title: project.study_title } as Study] : [];


### PR DESCRIPTION
## Resolves #444 

- This PR removes the project edit button for TRE ops staff as we agreed that they shouldn't be allowed to edit a project,
- For now, I have just set the behaviour back to how it used to be, so only the project creator sees the edit button. But we may want to follow up on this to give edit permissions to other users such as study admins.

<!--
For example "Resolves #42" if this PR resolves issue 42
-->

### Checklist

- [ ] Documentation has been updated
