### PR TITLE
adding safety net to cypress auth commands

### DIFF
--- a/web/cypress/support/auth.ts
+++ b/web/cypress/support/auth.ts
@@ -23,8 +23,14 @@ export function login(username: string, password: string): void {
       cy.get('input[type="password"]').type(password, {
         log: false,
       });
-      cy.get('input[type="submit"]').click();
+      cy.get('input[type="submit"]').click(); // Click "Sign in" on the password page
+
+      // Wait for "Stay signed in?" page, then click Yes
+      cy.contains("Stay signed in?").should("be.visible");
       cy.get('input[type="submit"]').click();
     }
   );
+
+  // Wait for OAuth redirect chain to complete before returning
+  cy.url().should("not.include", "microsoftonline.com");
 }

--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -377,96 +377,127 @@ declare global {
   }
 }
 
+const sessionOptions: Cypress.SessionOptions = {
+  // automatically re-run the full login if the session is not valid
+  validate() {
+    cy.request({ url: "/web/api/v0/auth", failOnStatusCode: false }).its("status").should("eq", 200);
+  },
+};
+
 Cypress.Commands.add("loginAsAdmin", () => {
   // See: https://docs.cypress.io/app/guides/authentication-testing/azure-active-directory-authentication
-  cy.session(`login-admin`, () => {
-    const log = Cypress.log({
-      displayName: "Entra ID Admin Login",
-      message: [`🔐 Authenticating admin`],
-      autoEnd: false,
-    });
+  cy.session(
+    `login-admin`,
+    () => {
+      const log = Cypress.log({
+        displayName: "Entra ID Admin Login",
+        message: [`🔐 Authenticating admin`],
+        autoEnd: false,
+      });
 
-    log.snapshot("before");
-    login(botAdminUsername, botAdminPassword);
+      log.snapshot("before");
+      login(botAdminUsername, botAdminPassword);
 
-    log.snapshot("after");
-    log.end();
-  });
+      log.snapshot("after");
+      log.end();
+    },
+    sessionOptions
+  );
 });
 
 Cypress.Commands.add("loginAsBase", () => {
-  cy.session(`login-base`, () => {
-    const log = Cypress.log({
-      displayName: "Entra ID Base user Login",
-      message: [`🔐 Authenticating base user`],
-      autoEnd: false,
-    });
+  cy.session(
+    `login-base`,
+    () => {
+      const log = Cypress.log({
+        displayName: "Entra ID Base user Login",
+        message: [`🔐 Authenticating base user`],
+        autoEnd: false,
+      });
 
-    log.snapshot("before");
-    login(botBaseUsername, botBasePassword);
-    log.snapshot("after");
-    log.end();
-  });
+      log.snapshot("before");
+      login(botBaseUsername, botBasePassword);
+      log.snapshot("after");
+      log.end();
+    },
+    sessionOptions
+  );
 });
 
 Cypress.Commands.add("loginAsStaff", () => {
-  cy.session(`login-staff`, () => {
-    const log = Cypress.log({
-      displayName: "Entra ID staff user Login",
-      message: [`🔐 Authenticating staff user`],
-      autoEnd: false,
-    });
+  cy.session(
+    `login-staff`,
+    () => {
+      const log = Cypress.log({
+        displayName: "Entra ID staff user Login",
+        message: [`🔐 Authenticating staff user`],
+        autoEnd: false,
+      });
 
-    log.snapshot("before");
-    login(botStaffUsername, botStaffPassword);
-    log.snapshot("after");
-    log.end();
-  });
+      log.snapshot("before");
+      login(botStaffUsername, botStaffPassword);
+      log.snapshot("after");
+      log.end();
+    },
+    sessionOptions
+  );
 });
 
 Cypress.Commands.add("loginAsIGOps", () => {
-  cy.session(`login-ig-ops`, () => {
-    const log = Cypress.log({
-      displayName: "Entra ID IG operations user Login",
-      message: [`🔐 Authenticating IG user`],
-      autoEnd: false,
-    });
+  cy.session(
+    `login-ig-ops`,
+    () => {
+      const log = Cypress.log({
+        displayName: "Entra ID IG operations user Login",
+        message: [`🔐 Authenticating IG user`],
+        autoEnd: false,
+      });
 
-    log.snapshot("before");
-    login(botIGUsername, botIGPassword);
-    log.snapshot("after");
-    log.end();
-  });
+      log.snapshot("before");
+      login(botIGUsername, botIGPassword);
+      log.snapshot("after");
+      log.end();
+    },
+    sessionOptions
+  );
 });
 
 Cypress.Commands.add("loginAsTREOps", () => {
-  cy.session(`login-tre-ops`, () => {
-    const log = Cypress.log({
-      displayName: "Entra ID TRE operations user Login",
-      message: [`🔐 Authenticating TRE ops user`],
-      autoEnd: false,
-    });
+  cy.session(
+    `login-tre-ops`,
+    () => {
+      const log = Cypress.log({
+        displayName: "Entra ID TRE operations user Login",
+        message: [`🔐 Authenticating TRE ops user`],
+        autoEnd: false,
+      });
 
-    log.snapshot("before");
-    login(botTREUsername, botTREPassword);
-    log.snapshot("after");
-    log.end();
-  });
+      log.snapshot("before");
+      login(botTREUsername, botTREPassword);
+      log.snapshot("after");
+      log.end();
+    },
+    sessionOptions
+  );
 });
 
 Cypress.Commands.add("loginAsDSHOps", () => {
-  cy.session(`login-dsh-ops`, () => {
-    const log = Cypress.log({
-      displayName: "Entra ID DSH operations user Login",
-      message: [`🔐 Authenticating DSH ops user`],
-      autoEnd: false,
-    });
+  cy.session(
+    `login-dsh-ops`,
+    () => {
+      const log = Cypress.log({
+        displayName: "Entra ID DSH operations user Login",
+        message: [`🔐 Authenticating DSH ops user`],
+        autoEnd: false,
+      });
 
-    log.snapshot("before");
-    login(botDSHUsername, botDSHPassword);
-    log.snapshot("after");
-    log.end();
-  });
+      log.snapshot("before");
+      login(botDSHUsername, botDSHPassword);
+      log.snapshot("after");
+      log.end();
+    },
+    sessionOptions
+  );
 });
 
 Cypress.Commands.add("clearChosenName", () => {


### PR DESCRIPTION
- A quick PR to address a strange issue that started happening just today.
- For some reason, running cypress tests locally kept getting stuck on the "Stay signed in?" page during the auth command.
- This may have been due to some test commands triggering too early which meant certain elements were not yet visible to be clicked (no idea why this just started happening today though).
- So this PR adds a few safety nets to make sure that each step of the auth process completes fully and also retries if something goes wrong.
- Might be good for someone to verify that this works locally for them too

<!--
For example "Resolves #42" if this PR resolves issue 42
-->

### Checklist

- [ ] Documentation has been updated
