### PR TITLE
preventing content flicker

### DIFF
--- a/web/src/components/studies/manage/StudyAgreement.tsx
+++ b/web/src/components/studies/manage/StudyAgreement.tsx
@@ -1,10 +1,5 @@
 import { useEffect, useState } from "react";
-import {
-  Agreement,
-  getAgreementsByAgreementType,
-  getStudiesByStudyIdAgreements,
-  postStudiesByStudyIdAgreements,
-} from "@/openapi";
+import { Agreement, getAgreementsByAgreementType, postStudiesByStudyIdAgreements } from "@/openapi";
 import { extractErrorMessage } from "@/lib/errorHandler";
 import AgreementForm from "@/components/ui/agreements/AgreementForm";
 import AgreementText from "@/components/ui/agreements/AgreementText";
@@ -19,9 +14,7 @@ type StudyAgreementProps = {
   setAgreementCompleted: (completed: boolean) => void;
 };
 
-export default function StudyAgreement(props: StudyAgreementProps) {
-  const { studyId, studyTitle, setAgreementCompleted } = props;
-
+export default function StudyAgreement({ studyId, studyTitle, setAgreementCompleted }: StudyAgreementProps) {
   const [studyAgreementText, setStudyAgreementText] = useState<Agreement | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -29,7 +22,7 @@ export default function StudyAgreement(props: StudyAgreementProps) {
   const isIAO = userData?.roles.includes("information-asset-owner");
 
   useEffect(() => {
-    const fetchStudyAgreementData = async () => {
+    const fetchAgreementText = async () => {
       setIsLoading(true);
 
       try {
@@ -41,20 +34,6 @@ export default function StudyAgreement(props: StudyAgreementProps) {
           return;
         }
         setStudyAgreementText(agreementTextResult.data);
-
-        // Check if the user has already accepted the study agreement
-        const studyAgreementsResult = await getStudiesByStudyIdAgreements({ path: { studyId } });
-        if (!studyAgreementsResult.response.ok || !studyAgreementsResult.data) {
-          const errorMsg = extractErrorMessage(studyAgreementsResult);
-          setError(`Failed to load study agreements: ${errorMsg}`);
-          return;
-        }
-        const confirmedAgreements = studyAgreementsResult.data.usernames;
-        const isConfirmed = userData?.username && confirmedAgreements.includes(userData?.username);
-
-        if (isConfirmed) {
-          setAgreementCompleted(true);
-        }
       } catch (err) {
         console.error("Failed to load study agreement:", err);
         setError("Failed to load study agreement. Please try again later.");
@@ -63,10 +42,10 @@ export default function StudyAgreement(props: StudyAgreementProps) {
       }
     };
 
-    fetchStudyAgreementData();
-  }, [studyId, setAgreementCompleted, userData]);
+    fetchAgreementText();
+  }, []);
 
-  if (isLoading) return <Loading message="Checking if all study agreements are present..." />;
+  if (isLoading) return <Loading message="Loading study agreement..." />;
 
   if (!studyAgreementText) return <div>No study agreement could be found.</div>;
 

--- a/web/src/components/studies/manage/StudySetupSteps.tsx
+++ b/web/src/components/studies/manage/StudySetupSteps.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useState } from "react";
-import { Asset, Study } from "@/openapi";
+import { Asset, Study, getStudiesByStudyIdAgreements } from "@/openapi";
+import { extractErrorMessage } from "@/lib/errorHandler";
 import StepProgress from "../../ui/steps/StepProgress";
 import StepArrow from "../../ui/steps/StepArrow";
 import StudyAgreement from "./StudyAgreement";
 import Assets from "../../assets/Assets";
+import Loading from "../../ui/Loading";
+import { useAuth } from "@/hooks/useAuth";
+import { Alert, AlertMessage } from "../../shared/uikitExports";
 
 type StudySetupStepsProps = {
   study: Study;
@@ -14,12 +18,39 @@ type StudySetupStepsProps = {
 
 export default function StudySetupSteps({ study, assets, setAssets, onStepsComplete }: StudySetupStepsProps) {
   const [agreementCompleted, setAgreementCompleted] = useState(false);
+  const [isCheckingAgreement, setIsCheckingAgreement] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { userData } = useAuth();
   const hasAsset = assets.length > 0;
   const isComplete = agreementCompleted && hasAsset;
 
   useEffect(() => {
     if (isComplete) onStepsComplete();
   }, [isComplete, onStepsComplete]);
+
+  useEffect(() => {
+    const checkStudyAgreement = async () => {
+      try {
+        const result = await getStudiesByStudyIdAgreements({ path: { studyId: study.id } });
+        if (!result.response.ok || !result.data) {
+          const errorMsg = extractErrorMessage(result);
+          setError(`Failed to load study agreements: ${errorMsg}`);
+          return;
+        }
+        const isConfirmed = userData?.username && result.data.usernames.includes(userData.username);
+        if (isConfirmed) setAgreementCompleted(true);
+      } catch (error) {
+        console.error("Failed to check study agreement:", error);
+        setError("Failed to check study agreement. Please try again later.");
+      } finally {
+        setIsCheckingAgreement(false);
+      }
+    };
+
+    checkStudyAgreement();
+  }, [study.id, userData]);
+
+  if (isCheckingAgreement) return <Loading message="Checking study setup..." />;
 
   const studySteps: Step[] = [
     {
@@ -41,6 +72,12 @@ export default function StudySetupSteps({ study, assets, setAssets, onStepsCompl
 
   return (
     <>
+      {error && (
+        <Alert type="error">
+          <AlertMessage>{error}</AlertMessage>
+        </Alert>
+      )}
+
       <StepProgress
         steps={studySteps}
         isComplete={isComplete}


### PR DESCRIPTION
- Another quick refactoring PR to prevent the brief content flicker on the manage study page
- This PR just moves the study agreement check into `StudySetupSteps` so that a loading message can be shown, it felt right to put it there but happy to reconsider if anyone feels strongly 

<!--
For example "Resolves #42" if this PR resolves issue 42
-->

### Checklist

- [ ] Documentation has been updated
