### PR TITLE
Asset expiry

### DIFF
--- a/api/web.yaml
+++ b/api/web.yaml
@@ -1356,7 +1356,6 @@ components:
         - accessed_by_third_parties
         - third_party_agreement
         - status
-        - contract_ids
       properties:
         title:
           type: string
@@ -1425,12 +1424,6 @@ components:
             - awaiting
             - destroyed
           description: Status of the asset
-        contract_ids:
-          type: array
-          description: List of contract IDs associated with the asset (empty array if none)
-          items:
-            type: string
-
     Asset:
       allOf:
         - $ref: "#/components/schemas/AssetBase"
@@ -1441,6 +1434,7 @@ components:
             - study_id
             - created_at
             - updated_at
+            - contract_ids
           properties:
             id:
               type: string
@@ -1457,6 +1451,11 @@ components:
             updated_at:
               type: string
               description: Time in RFC3339 format when the asset was last updated
+            contract_ids:
+              type: array
+              description: List of contract IDs associated with the asset (empty array if none)
+              items:
+                type: string
       description: A research study asset
 
     StudyBase:

--- a/api/web.yaml
+++ b/api/web.yaml
@@ -1351,7 +1351,6 @@ components:
         - legal_basis
         - format
         - requires_contract
-        - expires_at
         - has_dspt
         - stored_outside_uk_eea
         - accessed_by_third_parties
@@ -1408,6 +1407,7 @@ components:
           description: Format of the asset
         expires_at:
           type: string
+          nullable: true
           description: Retention expiry date of the asset
         requires_contract:
           type: boolean

--- a/internal/graceful/db.go
+++ b/internal/graceful/db.go
@@ -55,7 +55,6 @@ func InitDB() {
 
 	migrateContractStudyIds(db)
 	migrateContracts(db)
-	migrateAssetExpiresAt(db)
 
 	// Set up a sequence for the study caseref
 	// this must exist before AutoMigrate is run below, as the Caseref column default references it
@@ -145,34 +144,6 @@ func migrateContracts(db *gorm.DB) {
 	}
 
 	log.Info().Msg("Migrated contracts")
-}
-
-// Drop the NOT NULL constraint on assets.expires_at to make expiry optional
-func migrateAssetExpiresAt(db *gorm.DB) {
-	migrator := db.Migrator()
-
-	if !migrator.HasTable(&types.Asset{}) {
-		return
-	}
-
-	// Check if the column is already nullable
-	var count int64
-	err := db.Raw(`
-		SELECT COUNT(*) FROM information_schema.columns
-		WHERE table_name = 'assets' AND column_name = 'expires_at' AND is_nullable = 'NO'
-	`).Scan(&count).Error
-	if err != nil {
-		panic(err)
-	}
-	if count == 0 {
-		return // already nullable, nothing to do
-	}
-
-	if err := db.Exec(`ALTER TABLE assets ALTER COLUMN expires_at DROP NOT NULL`).Error; err != nil {
-		panic(err)
-	}
-
-	log.Info().Msg("Migrated asset expires_at to nullable")
 }
 
 // Set a study id column of contracts using their existing values

--- a/internal/graceful/db.go
+++ b/internal/graceful/db.go
@@ -149,19 +149,30 @@ func migrateContracts(db *gorm.DB) {
 
 // Drop the NOT NULL constraint on assets.expires_at to make expiry optional
 func migrateAssetExpiresAt(db *gorm.DB) {
-	if !db.Migrator().HasTable(&types.Asset{}) {
+	migrator := db.Migrator()
+
+	if !migrator.HasTable(&types.Asset{}) {
 		return
 	}
-	db.Exec(`
-		DO $$ BEGIN
-			IF EXISTS (
-				SELECT 1 FROM information_schema.columns
-				WHERE table_name = 'assets' AND column_name = 'expires_at' AND is_nullable = 'NO'
-			) THEN
-				ALTER TABLE assets ALTER COLUMN expires_at DROP NOT NULL;
-			END IF;
-		END $$;
-	`)
+
+	// Check if the column is already nullable
+	var count int64
+	err := db.Raw(`
+		SELECT COUNT(*) FROM information_schema.columns
+		WHERE table_name = 'assets' AND column_name = 'expires_at' AND is_nullable = 'NO'
+	`).Scan(&count).Error
+	if err != nil {
+		panic(err)
+	}
+	if count == 0 {
+		return // already nullable, nothing to do
+	}
+
+	if err := db.Exec(`ALTER TABLE assets ALTER COLUMN expires_at DROP NOT NULL`).Error; err != nil {
+		panic(err)
+	}
+
+	log.Info().Msg("Migrated asset expires_at to nullable")
 }
 
 // Set a study id column of contracts using their existing values

--- a/internal/graceful/db.go
+++ b/internal/graceful/db.go
@@ -55,6 +55,7 @@ func InitDB() {
 
 	migrateContractStudyIds(db)
 	migrateContracts(db)
+	migrateAssetExpiresAt(db)
 
 	// Set up a sequence for the study caseref
 	// this must exist before AutoMigrate is run below, as the Caseref column default references it
@@ -144,6 +145,23 @@ func migrateContracts(db *gorm.DB) {
 	}
 
 	log.Info().Msg("Migrated contracts")
+}
+
+// Drop the NOT NULL constraint on assets.expires_at to make expiry optional
+func migrateAssetExpiresAt(db *gorm.DB) {
+	if !db.Migrator().HasTable(&types.Asset{}) {
+		return
+	}
+	db.Exec(`
+		DO $$ BEGIN
+			IF EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_name = 'assets' AND column_name = 'expires_at' AND is_nullable = 'NO'
+			) THEN
+				ALTER TABLE assets ALTER COLUMN expires_at DROP NOT NULL;
+			END IF;
+		END $$;
+	`)
 }
 
 // Set a study id column of contracts using their existing values

--- a/internal/handler/web/assets.go
+++ b/internal/handler/web/assets.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/ucl-arc-tre/portal/internal/config"
@@ -11,6 +12,14 @@ import (
 )
 
 // Helper functions
+
+func formatExpiresAt(expiresAt *time.Time) *string {
+	if expiresAt == nil {
+		return nil
+	}
+	formattedDateTime := expiresAt.Format(config.TimeFormat)
+	return &formattedDateTime
+}
 
 func assetToOpenApiAsset(asset types.Asset) openapi.Asset {
 	contractIds := []string{}
@@ -28,7 +37,7 @@ func assetToOpenApiAsset(asset types.Asset) openapi.Asset {
 		Protection:           openapi.AssetProtection(asset.Protection),
 		LegalBasis:           openapi.AssetLegalBasis(asset.LegalBasis),
 		Format:               openapi.AssetFormat(asset.Format),
-		ExpiresAt:            asset.ExpiresAt.Format(config.TimeFormat),
+		ExpiresAt:            formatExpiresAt(asset.ExpiresAt),
 		Locations:            asset.LocationStrings(),
 		RequiresContract:     asset.RequiresContract,
 		HasDspt:              asset.HasDspt,

--- a/internal/openapi/web/main.gen.go
+++ b/internal/openapi/web/main.gen.go
@@ -510,9 +510,6 @@ type AssetBase struct {
 	// ClassificationImpact Classification level of the asset
 	ClassificationImpact AssetBaseClassificationImpact `json:"classification_impact"`
 
-	// ContractIds List of contract IDs associated with the asset (empty array if none)
-	ContractIds []string `json:"contract_ids"`
-
 	// Description Description of the asset
 	Description string `json:"description"`
 

--- a/internal/openapi/web/main.gen.go
+++ b/internal/openapi/web/main.gen.go
@@ -448,7 +448,7 @@ type Asset struct {
 	Description string `json:"description"`
 
 	// ExpiresAt Retention expiry date of the asset
-	ExpiresAt string `json:"expires_at"`
+	ExpiresAt *string `json:"expires_at,omitempty"`
 
 	// Format Format of the asset
 	Format AssetFormat `json:"format"`
@@ -517,7 +517,7 @@ type AssetBase struct {
 	Description string `json:"description"`
 
 	// ExpiresAt Retention expiry date of the asset
-	ExpiresAt string `json:"expires_at"`
+	ExpiresAt *string `json:"expires_at,omitempty"`
 
 	// Format Format of the asset
 	Format AssetBaseFormat `json:"format"`

--- a/internal/service/studies/assets.go
+++ b/internal/service/studies/assets.go
@@ -80,10 +80,11 @@ func (s *Service) validateAssetData(assetData openapi.AssetBase) (*openapi.Valid
 		return &openapi.ValidationError{ErrorMessage: "format must be one of: electronic, paper, other"}, nil
 	}
 
-	// Validate expiry field
-	_, err := time.Parse(config.DateFormat, assetData.ExpiresAt)
-	if err != nil {
-		return &openapi.ValidationError{ErrorMessage: "expiry date must be in YYYY-MM-DD format"}, nil
+	// Validate expiry field if provided
+	if assetData.ExpiresAt != nil {
+		if _, err := time.Parse(config.DateFormat, *assetData.ExpiresAt); err != nil {
+			return &openapi.ValidationError{ErrorMessage: "expiry date must be in YYYY-MM-DD format"}, nil
+		}
 	}
 
 	// Validate status field
@@ -100,9 +101,13 @@ func (s *Service) validateAssetData(assetData openapi.AssetBase) (*openapi.Valid
 }
 
 func assetFromBase(assetData openapi.AssetBase) (*types.Asset, error) {
-	expiryDate, err := time.Parse(config.DateFormat, assetData.ExpiresAt)
-	if err != nil {
-		return nil, types.NewErrInvalidObject(fmt.Sprintf("failed to parse validated expiry date %s: %v", assetData.ExpiresAt, err))
+	var expiresAt *time.Time
+	if assetData.ExpiresAt != nil {
+		parsedDateTime, err := time.Parse(config.DateFormat, *assetData.ExpiresAt)
+		if err != nil {
+			return nil, types.NewErrInvalidObject(fmt.Sprintf("failed to parse validated expiry date %s: %v", *assetData.ExpiresAt, err))
+		}
+		expiresAt = &parsedDateTime
 	}
 
 	asset := &types.Asset{
@@ -113,7 +118,7 @@ func assetFromBase(assetData openapi.AssetBase) (*types.Asset, error) {
 		Protection:           string(assetData.Protection),
 		LegalBasis:           string(assetData.LegalBasis),
 		Format:               string(assetData.Format),
-		ExpiresAt:            expiryDate,
+		ExpiresAt:            expiresAt,
 		HasDspt:              assetData.HasDspt,
 		RequiresContract:     assetData.RequiresContract,
 		StoredOutsideUkEea:   assetData.StoredOutsideUkEea,

--- a/internal/service/studies/assets_test.go
+++ b/internal/service/studies/assets_test.go
@@ -13,6 +13,8 @@ import (
 	openapi "github.com/ucl-arc-tre/portal/internal/openapi/web"
 )
 
+func ptr[T any](value T) *T { return &value }
+
 func validAssetBase() openapi.AssetBase {
 	return openapi.AssetBase{
 		Title:                "Valid Asset",
@@ -23,7 +25,7 @@ func validAssetBase() openapi.AssetBase {
 		Protection:           openapi.AssetBaseProtectionAnonymisation,
 		LegalBasis:           openapi.AssetBaseLegalBasisConsent,
 		Format:               openapi.AssetBaseFormatElectronic,
-		ExpiresAt:            time.Now().Format(config.DateFormat),
+		ExpiresAt:            ptr(time.Now().Format(config.DateFormat)),
 		Status:               openapi.AssetBaseStatusActive,
 	}
 }
@@ -70,7 +72,14 @@ func TestValidateAssetData(t *testing.T) {
 		{
 			name: "valid expiry date",
 			modify: func(a *openapi.AssetBase) {
-				a.ExpiresAt = "2025-12-31"
+				a.ExpiresAt = ptr("2025-12-31")
+			},
+			wantError: false,
+		},
+		{
+			name: "no expiry date",
+			modify: func(a *openapi.AssetBase) {
+				a.ExpiresAt = nil
 			},
 			wantError: false,
 		},
@@ -137,7 +146,7 @@ func TestValidateAssetData(t *testing.T) {
 		{
 			name: "invalid expiry date",
 			modify: func(a *openapi.AssetBase) {
-				a.ExpiresAt = "not-a-date"
+				a.ExpiresAt = ptr("not-a-date")
 			},
 			wantError: true,
 		},

--- a/internal/service/studies/integration_test.go
+++ b/internal/service/studies/integration_test.go
@@ -16,6 +16,8 @@ import (
 	openapi "github.com/ucl-arc-tre/portal/internal/openapi/web"
 )
 
+func ptr[T any](value T) *T { return &value }
+
 // To be called by each test within this package to AutoMigrate
 // only the models/tables required by this package
 func migrate(db *gorm.DB) error {
@@ -74,7 +76,7 @@ func TestIntegration_CreateAsset(t *testing.T) {
 		Protection:           openapi.AssetBaseProtectionAnonymisation,
 		LegalBasis:           openapi.AssetBaseLegalBasisConsent,
 		Format:               openapi.AssetBaseFormatElectronic,
-		ExpiresAt:            time.Now().AddDate(1, 0, 0).Format("2006-01-02"),
+		ExpiresAt:            ptr(time.Now().AddDate(1, 0, 0).Format("2006-01-02")),
 		Status:               openapi.AssetBaseStatusActive,
 	}
 

--- a/internal/types/studies.go
+++ b/internal/types/studies.go
@@ -82,11 +82,11 @@ type Asset struct {
 	Protection           string    `gorm:"not null"`
 	LegalBasis           string    `gorm:"not null"`
 	Format               string    `gorm:"not null"`
-	ExpiresAt            time.Time `gorm:"not null"`
-	RequiresContract     bool      `gorm:"not null;default:false"`
-	HasDspt              bool      `gorm:"not null;default:false"`
-	StoredOutsideUkEea   bool      `gorm:"not null;default:false"`
-	Status               string    `gorm:"not null"`
+	ExpiresAt            *time.Time
+	RequiresContract     bool   `gorm:"not null;default:false"`
+	HasDspt              bool   `gorm:"not null;default:false"`
+	StoredOutsideUkEea   bool   `gorm:"not null;default:false"`
+	Status               string `gorm:"not null"`
 
 	// Relationships
 	CreatorUser User            `gorm:"foreignKey:CreatorUserID"`

--- a/web/cypress/e2e/integration/studies/creation.cy.ts
+++ b/web/cypress/e2e/integration/studies/creation.cy.ts
@@ -47,6 +47,7 @@ describe("Study creation end-to-end", () => {
     cy.get('[name="protection"]').select("anonymisation");
     cy.get('[name="legal_basis"]').select("consent");
     cy.get('[name="format"]').select("electronic");
+    cy.get("input[name='has_expiry_date'][value='true']").check({ force: true });
     cy.get('[name="expires_at"]').type("2022-01-01");
     cy.get('[data-cy="create-asset-form"] input[value="arc_tre"]').check();
     cy.get("input[name='requires_contract'][value='false']").check({ force: true });
@@ -115,6 +116,7 @@ describe("Study creation end-to-end", () => {
     cy.get('[name="protection"]').select("anonymisation");
     cy.get('[name="legal_basis"]').select("consent");
     cy.get('[name="format"]').select("electronic");
+    cy.get("input[name='has_expiry_date'][value='true']").check({ force: true });
     cy.get('[name="expires_at"]').type("2022-01-01");
     cy.get('[data-cy="create-asset-form"] input[value="arc_tre"]').check();
     cy.get("input[name='requires_contract'][value='false']").check({ force: true });

--- a/web/src/components/assets/AssetCard.tsx
+++ b/web/src/components/assets/AssetCard.tsx
@@ -4,8 +4,9 @@ import { useRouter } from "next/router";
 import styles from "./AssetCard.module.css";
 import { Alert, AlertCircleIcon, AlertMessage } from "../shared/uikitExports";
 import { useEffect, useState } from "react";
-import { formatDate } from "../shared/exports";
+import { calculateExpiryUrgency, formatDate } from "../shared/exports";
 import { checkAllRequiredAssetContractsLinked } from "../studies/manage/lib/assetContractLinks";
+import ExpiryWarning from "../ui/ExpiryWarning";
 
 type AssetCardProps = {
   asset: Asset;
@@ -39,6 +40,8 @@ export default function AssetCard(props: AssetCardProps) {
   const router = useRouter();
   const [isCompleted, setIsCompleted] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const expiryUrgency = asset.expires_at ? calculateExpiryUrgency(new Date(asset.expires_at)) : null;
 
   useEffect(() => {
     const isAssetCompleted = async () => {
@@ -108,6 +111,8 @@ export default function AssetCard(props: AssetCardProps) {
       )}
 
       <div className={styles["asset-actions"]}>
+        {expiryUrgency && <ExpiryWarning expiryUrgency={expiryUrgency} entityName="asset" />}
+
         {!isCompleted && (
           <>
             <small className={styles["asset-incomplete__message"]}>

--- a/web/src/components/assets/AssetCreationForm.tsx
+++ b/web/src/components/assets/AssetCreationForm.tsx
@@ -37,7 +37,8 @@ export default function AssetCreationForm(props: AssetFormProps) {
       protection: "",
       legal_basis: "",
       format: "",
-      expires_at: "",
+      has_expiry_date: false,
+      expires_at: null,
       locations: [],
       requires_contract: false,
       has_dspt: false,
@@ -56,7 +57,8 @@ export default function AssetCreationForm(props: AssetFormProps) {
         protection: editingAsset.protection,
         legal_basis: editingAsset.legal_basis,
         format: editingAsset.format,
-        expires_at: editingAsset.expires_at.slice(0, 10),
+        has_expiry_date: editingAsset.expires_at ? "true" : "false",
+        expires_at: editingAsset.expires_at ? editingAsset.expires_at.split("T")[0] : null,
         locations: editingAsset.locations,
         requires_contract: String(editingAsset.requires_contract),
         has_dspt: String(editingAsset.has_dspt),
@@ -72,7 +74,8 @@ export default function AssetCreationForm(props: AssetFormProps) {
         protection: "",
         legal_basis: "",
         format: "",
-        expires_at: "",
+        has_expiry_date: false,
+        expires_at: null,
         locations: [],
         requires_contract: false,
         has_dspt: false,
@@ -84,8 +87,10 @@ export default function AssetCreationForm(props: AssetFormProps) {
 
   const protectionValue = watch("protection");
   const classificationValue = watch("classification_impact");
+  const hasExpiryDateValue = watch("has_expiry_date");
   const showUCLGuidanceText = protectionValue === "anonymisation" || protectionValue === "pseudonymisation";
   const showTierSelection = classificationValue === "highly_confidential";
+  const showExpiryDate = hasExpiryDateValue === "true" || hasExpiryDateValue === true;
 
   const onFormSubmit = async (data: AssetFormData) => {
     try {
@@ -107,6 +112,7 @@ export default function AssetCreationForm(props: AssetFormProps) {
       const transformedAssetData: AssetFormData = {
         ...data,
         tier,
+        expires_at: showExpiryDate ? data.expires_at : null,
         requires_contract: data.requires_contract === "true" || data.requires_contract === true,
         has_dspt: data.has_dspt === "true" || data.has_dspt === true,
         stored_outside_uk_eea: data.stored_outside_uk_eea === "true" || data.stored_outside_uk_eea === true,
@@ -358,24 +364,57 @@ export default function AssetCreationForm(props: AssetFormProps) {
         </div>
 
         <div className={styles.field}>
-          <Label htmlFor="expires_at" className={styles["red-text"]}>
-            What is the asset&apos;s retention expiry date? *
-          </Label>
-          <input
-            id="expires_at"
-            type="date"
-            {...register("expires_at", {
-              required: "Expiry date is required",
-            })}
-            aria-invalid={!!errors.expires_at}
-            className={errors.expires_at ? styles.error : ""}
-          />
-          {errors.expires_at && (
+          <Label htmlFor="has_expiry_date">Does this asset have a retention expiry date? *</Label>
+          <div className={styles["radio-group"]}>
+            <label className={styles["radio-label"]}>
+              <input
+                type="radio"
+                value="true"
+                {...register("has_expiry_date", {
+                  required: "Please select yes or no",
+                })}
+                className={styles.radio}
+              />
+              Yes
+            </label>
+            <label className={styles["radio-label"]}>
+              <input
+                type="radio"
+                value="false"
+                {...register("has_expiry_date", {
+                  required: "Please select yes or no",
+                })}
+                className={styles.radio}
+              />
+              No
+            </label>
+          </div>
+          {errors.has_expiry_date && (
             <Alert type="error">
-              <AlertMessage>{errors.expires_at.message}</AlertMessage>
+              <AlertMessage>{errors.has_expiry_date.message}</AlertMessage>
             </Alert>
           )}
         </div>
+
+        {showExpiryDate && (
+          <div className={styles.field}>
+            <Label htmlFor="expires_at">What is the asset&apos;s retention expiry date? *</Label>
+            <input
+              id="expires_at"
+              type="date"
+              {...register("expires_at", {
+                required: showExpiryDate ? "Expiry date is required" : false,
+              })}
+              aria-invalid={!!errors.expires_at}
+              className={errors.expires_at ? styles.error : ""}
+            />
+            {errors.expires_at && (
+              <Alert type="error">
+                <AlertMessage>{errors.expires_at.message}</AlertMessage>
+              </Alert>
+            )}
+          </div>
+        )}
 
         <div className={styles.field}>
           <Label htmlFor="location">

--- a/web/src/components/contracts/ContractCard.tsx
+++ b/web/src/components/contracts/ContractCard.tsx
@@ -1,8 +1,8 @@
 import Button from "@/components/ui/Button";
 import { Contract } from "@/openapi";
 import styles from "./ContractCard.module.css";
-import { AlertCircleIcon } from "../shared/uikitExports";
 import { calculateExpiryUrgency, formatDate } from "../shared/exports";
+import ExpiryWarning from "../ui/ExpiryWarning";
 import router from "next/router";
 
 type ContractCardProps = {
@@ -75,14 +75,7 @@ export default function ContractCard({ studyId, contract }: ContractCardProps) {
       </div>
 
       <div className={styles.actions}>
-        {expiryUrgency && (
-          <small className={styles["expiry-message"]}>
-            <AlertCircleIcon className={`expiry-urgency--${expiryUrgency.level} actions-icon`} />
-            {expiryUrgency.level === "critical"
-              ? "This contract has expired, please review and update as soon as possible"
-              : "This contract is expiring soon, please review and update if necessary"}
-          </small>
-        )}
+        {expiryUrgency && <ExpiryWarning expiryUrgency={expiryUrgency} entityName="contract" />}
         <div className={styles["button-wrapper"]}>
           <Button
             onClick={() => {

--- a/web/src/components/studies/manage/StudyTabs.tsx
+++ b/web/src/components/studies/manage/StudyTabs.tsx
@@ -16,7 +16,14 @@ export default function StudyTabs({ assets, contracts }: StudyTabsProps) {
   const setTab = (newTab: string) =>
     router.push({ query: { ...router.query, tab: newTab } }, undefined, { shallow: true });
 
-  const assetsNeedAttention = assets.some((asset) => asset.requires_contract && asset.contract_ids.length === 0);
+  const assetsNeedAttention = assets.some((asset) => {
+    if (asset.requires_contract && asset.contract_ids.length === 0) return true;
+    if (asset.expires_at) {
+      const urgency = calculateExpiryUrgency(new Date(asset.expires_at));
+      if (urgency !== null && urgency.level !== "low") return true;
+    }
+    return false;
+  });
 
   const contractsNeedAttention = contracts.some((contract) => {
     const urgency = calculateExpiryUrgency(new Date(contract.expiry_date));

--- a/web/src/components/ui/ExpiryWarning.tsx
+++ b/web/src/components/ui/ExpiryWarning.tsx
@@ -1,0 +1,17 @@
+import { AlertCircleIcon } from "../shared/uikitExports";
+
+type ExpiryWarningProps = {
+  expiryUrgency: ExpiryUrgency;
+  entityName: string;
+};
+
+export default function ExpiryWarning({ expiryUrgency, entityName }: ExpiryWarningProps) {
+  return (
+    <small>
+      <AlertCircleIcon className={`expiry-urgency--${expiryUrgency.level} actions-icon`} />
+      {expiryUrgency.level === "critical"
+        ? `This ${entityName} has expired, please review and update as soon as possible`
+        : `This ${entityName} is expiring soon, please review and update if necessary`}
+    </small>
+  );
+}

--- a/web/src/openapi/types.gen.ts
+++ b/web/src/openapi/types.gen.ts
@@ -170,7 +170,7 @@ export type AssetBase = {
     /**
      * Retention expiry date of the asset
      */
-    expires_at: string;
+    expires_at?: string | null;
     /**
      * Whether a contract is required for the asset
      */

--- a/web/src/openapi/types.gen.ts
+++ b/web/src/openapi/types.gen.ts
@@ -187,10 +187,6 @@ export type AssetBase = {
      * Status of the asset
      */
     status: 'active' | 'awaiting' | 'destroyed';
-    /**
-     * List of contract IDs associated with the asset (empty array if none)
-     */
-    contract_ids: Array<string>;
 };
 
 /**
@@ -217,6 +213,10 @@ export type Asset = AssetBase & {
      * Time in RFC3339 format when the asset was last updated
      */
     updated_at: string;
+    /**
+     * List of contract IDs associated with the asset (empty array if none)
+     */
+    contract_ids: Array<string>;
 };
 
 /**

--- a/web/src/pages/assets/ManageAsset.module.css
+++ b/web/src/pages/assets/ManageAsset.module.css
@@ -78,6 +78,12 @@
   border-top: 1px solid #e9ecef;
 }
 
+.expiry-warning {
+  text-align: center;
+  margin: 1.5rem 0;
+  font-size: 1.2rem;
+}
+
 .error {
   color: #dc3545;
   background: #f8d7da;

--- a/web/src/pages/assets/manage.tsx
+++ b/web/src/pages/assets/manage.tsx
@@ -25,7 +25,8 @@ import Breadcrumbs from "@/components/ui/Breadcrumbs";
 import ContractCard from "@/components/contracts/ContractCard";
 import { Alert, AlertMessage, HelperText } from "@/components/shared/uikitExports";
 import ApprovedResearcherFallback from "@/components/ui/ApprovedResearcherFallback";
-import { formatDate } from "@/components/shared/exports";
+import { calculateExpiryUrgency, formatDate } from "@/components/shared/exports";
+import ExpiryWarning from "@/components/ui/ExpiryWarning";
 import AssetCreationForm from "@/components/assets/AssetCreationForm";
 
 export default function ManageAssetPage() {
@@ -162,6 +163,8 @@ export default function ManageAssetPage() {
     );
   }
 
+  const expiryUrgency = asset.expires_at ? calculateExpiryUrgency(new Date(asset.expires_at)) : null;
+
   return (
     <>
       <MetaHead title={`Manage Asset: ${asset.title}`} description={`Manage asset details for ${asset.title}`} />
@@ -204,6 +207,12 @@ export default function ManageAssetPage() {
           </Alert>
         )}
 
+        {expiryUrgency && (
+          <div className={styles["expiry-warning"]}>
+            <ExpiryWarning expiryUrgency={expiryUrgency} entityName="asset" />
+          </div>
+        )}
+
         <div className={styles["asset-info"]}>
           <div className={styles.section}>
             <h3>Asset Details</h3>
@@ -241,7 +250,7 @@ export default function ManageAssetPage() {
             </div>
             <div className={styles.field}>
               <label>Expiry Date:</label>
-              <span>{formatDate(asset.expires_at)}</span>
+              <span>{asset.expires_at ? formatDate(asset.expires_at) : "None"}</span>
             </div>
             <div className={styles.field}>
               <label>Locations:</label>

--- a/web/src/types/assets.d.ts
+++ b/web/src/types/assets.d.ts
@@ -6,7 +6,8 @@ type AssetFormData = {
   protection: string;
   legal_basis: string;
   format: string;
-  expires_at: string;
+  has_expiry_date: boolean | string;
+  expires_at: string | null;
   locations: string[];
   requires_contract: boolean | string; // Can be string from form, converted to boolean
   has_dspt: boolean | string; // Can be string from form, converted to boolean


### PR DESCRIPTION
## Works towards #257 

- This PR adds the frontend and backend code for the assets expiry indicator,
- `expires_at` for assets is now optional,
- Added a reusable `ExpiryWarning` frontend component,
- The Assets tab on the study page now shows the attention indicator (!) for assets with an approaching or expired expiry date,
- Frontend and backend tests updated,
- Go migration code added (to be removed when deployed to prod),
- Drive-by: moved `contract_ids` from `AssetBase` to the `Asset` response type as it wasn't ever used on `AssetBase`

Screenshots:
<img width="1131" height="796" alt="Screenshot 2026-04-17 at 16 45 42" src="https://github.com/user-attachments/assets/b03835c0-7285-4d26-a73b-deb9d93d7005" />

<img width="1179" height="816" alt="Screenshot 2026-04-17 at 16 46 00" src="https://github.com/user-attachments/assets/9e6ffd0b-1d67-49c7-810a-221e528d6680" />


<!--
For example "Resolves #42" if this PR resolves issue 42
-->

### Checklist

- [ ] Documentation has been updated
