### PR TITLE
Add users and s3 interfaces, add MockS3 and MockUsers, add tests for c…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,6 +117,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/std-uritemplate/std-uritemplate/go/v2 v2.0.5 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tetratelabs/wazero v1.11.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -363,6 +363,7 @@ github.com/std-uritemplate/std-uritemplate/go/v2 v2.0.5/go.mod h1:Z5KcoM0YLC7INl
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/internal/controller/s3/interface.go
+++ b/internal/controller/s3/interface.go
@@ -1,0 +1,13 @@
+package s3
+
+import (
+	"context"
+
+	"github.com/ucl-arc-tre/portal/internal/types"
+)
+
+type Interface interface {
+	StoreObject(ctx context.Context, metadata ObjectMetadata, obj types.S3Object) error
+	GetObject(ctx context.Context, metadata ObjectMetadata) (types.S3Object, error)
+	DeleteObject(metadata ObjectMetadata) error
+}

--- a/internal/service/studies/integration_test.go
+++ b/internal/service/studies/integration_test.go
@@ -184,7 +184,7 @@ func TestIntegration_ValidateContract(t *testing.T) {
 		{
 			name: "invalid third party name",
 			modify: func(c *openapi.ContractBase) {
-				c.Title = "a"
+				c.ThirdPartyName = ptr("a")
 			},
 			expectErr: true,
 		},

--- a/internal/service/studies/integration_test.go
+++ b/internal/service/studies/integration_test.go
@@ -3,11 +3,15 @@
 package studies
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/ucl-arc-tre/portal/internal/controller/s3"
 	"github.com/ucl-arc-tre/portal/internal/testutil"
 	"gorm.io/gorm"
 
@@ -22,19 +26,14 @@ func ptr[T any](value T) *T { return &value }
 // only the models/tables required by this package
 func migrate(db *gorm.DB) error {
 
-	// enable uuid extension
-	if err := db.Exec(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`).Error; err != nil {
-		return err
-	}
-
-	// create sequence
-	if err := db.Exec(`CREATE SEQUENCE IF NOT EXISTS study_caseref_seq`).Error; err != nil {
-		return err
-	}
-
 	// Run migrations, only the models/tables required by this package
 	err := db.AutoMigrate(
+		&types.User{},
+		&types.Study{},
+		&types.Asset{},
 		&types.AssetLocation{},
+		&types.Contract{},
+		&types.ContractObjectMetadata{},
 	)
 	if err != nil {
 		return err
@@ -51,7 +50,7 @@ func TestIntegration_CreateAsset(t *testing.T) {
 	// Create unique schema for this test
 	db := testutil.NewTestDBSchema(t, migrate)
 
-	svc := &Service{db: db, entra: &testutil.FakeEntra{}}
+	svc := &Service{db: db, entra: &testutil.MockEntra{}}
 
 	user := types.User{
 		Username: "username",
@@ -103,4 +102,261 @@ func TestIntegration_CreateAsset(t *testing.T) {
 
 	locationValues := []string{locations[0].Location, locations[1].Location}
 	assert.ElementsMatch(t, []string{"UK", "EU"}, locationValues)
+}
+
+func TestIntegration_ValidateContract(t *testing.T) {
+
+	// Enable parallel test
+	t.Parallel()
+
+	now := time.Now()
+	later := now.Add(24 * time.Hour)
+
+	// Create unique schema for this test
+	db := testutil.NewTestDBSchema(t, migrate)
+
+	creator := types.User{
+		Username: "bob@example.com",
+	}
+	assert.NoError(t, db.Create(&creator).Error)
+
+	signatoryUser := types.User{
+		Username: "user1@",
+	}
+	assert.NoError(t, db.Create(&signatoryUser).Error)
+
+	study := types.Study{
+		OwnerUserID:    creator.ID,
+		ApprovalStatus: string(openapi.Incomplete), // Initial status is "Incomplete" until the contract and assets are created
+	}
+	assert.NoError(t, db.Create(&study).Error)
+	studyID := study.ID
+
+	asset := types.Asset{
+		CreatorUserID: creator.ID,
+		StudyID:       studyID,
+	}
+	assert.NoError(t, db.Create(&asset).Error)
+
+	validBase := openapi.ContractBase{
+		Title:                 "Valid Contract",
+		OrganisationSignatory: "user1@",
+		ThirdPartyName:        ptr("Third Party"),
+		Status:                openapi.ContractBaseStatusProposed,
+		StartDate:             ptr(now.Format("2006-01-02")),
+		ExpiryDate:            ptr(later.Format("2006-01-02")),
+		AssetIds:              []string{asset.ID.String()},
+	}
+
+	tests := []struct {
+		name      string
+		modify    func(*openapi.ContractBase)
+		mockUsers []types.Username
+		expectErr bool
+	}{
+		// =========================
+		//  VALID CASES
+		// =========================
+		{
+			name:      "valid contract (baseline)",
+			modify:    func(c *openapi.ContractBase) {},
+			mockUsers: []types.Username{signatoryUser.Username}, //[]string{"user1"},
+			expectErr: false,
+		},
+
+		// =========================
+		//  INVALID CASES
+		// =========================
+		{
+			name: "invalid title (too short)",
+			modify: func(c *openapi.ContractBase) {
+				c.Title = "x"
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid signatory",
+			modify: func(c *openapi.ContractBase) {
+				c.OrganisationSignatory = "bad@gmail.com"
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid third party name",
+			modify: func(c *openapi.ContractBase) {
+				c.Title = "a"
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid status",
+			modify: func(c *openapi.ContractBase) {
+				c.Status = "wrong"
+			},
+			expectErr: true,
+		},
+		{
+			name: "missing start date",
+			modify: func(c *openapi.ContractBase) {
+				c.StartDate = ptr("")
+			},
+			expectErr: true,
+		},
+
+		// =========================
+		//  EDGE CASES
+		// =========================
+		{
+			name: "start date after expiry",
+			modify: func(c *openapi.ContractBase) {
+				c.StartDate = ptr(later.Format("2006-01-02"))
+				c.ExpiryDate = ptr(now.Format("2006-01-02"))
+			},
+			expectErr: true,
+		},
+		{
+			name: "asset mismatch",
+			modify: func(c *openapi.ContractBase) {
+				c.AssetIds = []string{uuid.New().String()}
+			},
+			mockUsers: []types.Username{signatoryUser.Username}, //[]string{"user1"},
+			expectErr: true,
+		},
+		{
+			name:      "multiple users returned",
+			modify:    func(c *openapi.ContractBase) {},
+			mockUsers: []types.Username{types.Username("u1"), types.Username("u2")},
+			expectErr: true,
+		},
+	}
+
+	for _, curTest := range tests {
+		t.Run(curTest.name, func(t *testing.T) {
+			base := validBase
+			curTest.modify(&base)
+
+			ctx := context.Background()
+
+			// set up mocks
+			mockEntra := new(testutil.MockEntra)
+			mockEntra.On("FindUsernames", ctx, base.OrganisationSignatory).
+				Return(curTest.mockUsers, nil)
+
+			service := &Service{
+				db:    db,
+				entra: mockEntra,
+			}
+
+			err := service.validateContract(ctx, studyID, base)
+			if curTest.expectErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestIntegration_CreateContract(t *testing.T) {
+
+	// Enable parallel test
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Create unique schema for this test
+	db := testutil.NewTestDBSchema(t, migrate)
+
+	// stub entra + users + S3
+	entra := new(testutil.MockEntra)
+	users := new(testutil.MockUsers)
+	mockS3 := new(testutil.MockS3)
+
+	svc := &Service{
+		db:    db,
+		entra: entra,
+		users: users,
+		s3:    mockS3,
+	}
+
+	// set up required models
+	creator := types.User{
+		Username: "bob@example.com",
+	}
+	assert.NoError(t, db.Create(&creator).Error)
+
+	signatoryUser := types.User{
+		Username: "user1@",
+	}
+	assert.NoError(t, db.Create(&signatoryUser).Error)
+
+	study := types.Study{
+		OwnerUserID:    creator.ID,
+		ApprovalStatus: string(openapi.Incomplete), // Initial status is "Incomplete" until the contract and assets are created
+	}
+	assert.NoError(t, db.Create(&study).Error)
+	studyID := study.ID
+
+	asset := types.Asset{
+		CreatorUserID: creator.ID,
+		StudyID:       studyID,
+	}
+	assert.NoError(t, db.Create(&asset).Error)
+
+	contractBase := openapi.ContractBase{
+		Title:                 "Integration Contract",
+		OrganisationSignatory: "user1@",
+		ThirdPartyName:        ptr("Third Party"),
+		Status:                openapi.ContractBaseStatusProposed,
+		StartDate:             ptr("2024-01-01"),
+		ExpiryDate:            ptr("2024-12-31"),
+		AssetIds:              []string{asset.ID.String()},
+	}
+
+	// set up mocks
+	entra.On("FindUsernames", ctx, contractBase.OrganisationSignatory).
+		Return([]types.Username{signatoryUser.Username}, nil)
+
+	users.On("PersistedUser", types.Username(contractBase.OrganisationSignatory)).Return(signatoryUser, nil)
+
+	contract, err := svc.CreateContract(ctx, studyID, contractBase, creator)
+	assert.NoError(t, err)
+	assert.NotNil(t, contract)
+
+	s3Object := testutil.MockS3Object("integration test contract")
+	contractObjectmetadata := types.ContractObjectMetadata{
+		Filename:   "contract.pdf",
+		ContractID: contract.ID,
+	}
+
+	contractObject := ContractObject{
+		Object: s3Object,
+		Meta:   contractObjectmetadata,
+	}
+
+	mockS3.On("StoreObject",
+		mock.Anything,
+		mock.MatchedBy(func(m s3.ObjectMetadata) bool {
+			return m.Kind == s3.ContractKind
+		}), // this custom matcher checks only Kind == contract, and avoids checking strict equality of s3.ObjectMetadata.Id, which is dynamically generated in transaction
+		mock.Anything,
+	).Return(nil)
+
+	metadata, err := svc.CreateContractObject(ctx, studyID, contractObject)
+	assert.NoError(t, err)
+	assert.NotNil(t, metadata)
+
+	fetched, err := svc.GetContract(studyID, contract.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, fetched)
+
+	// Verification
+	assert.Equal(t, contract.ID, metadata.ContractID)
+	assert.Equal(t, contract.ID, fetched.ID)
+	assert.Len(t, fetched.Assets, 1)
+	assert.Equal(t, signatoryUser.ID, fetched.SignatoryUser.ID)
+
+	assert.Equal(t, studyID, fetched.StudyID)
+	assert.Equal(t, creator.ID, fetched.CreatorUserID)
+
 }

--- a/internal/service/studies/integration_test.go
+++ b/internal/service/studies/integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/ucl-arc-tre/portal/internal/config"
 	"github.com/ucl-arc-tre/portal/internal/controller/s3"
 	"github.com/ucl-arc-tre/portal/internal/testutil"
 	"gorm.io/gorm"
@@ -115,13 +116,19 @@ func TestIntegration_ValidateContract(t *testing.T) {
 	// Create unique schema for this test
 	db := testutil.NewTestDBSchema(t, migrate)
 
+	// set up test config
+	config.Init()
+	if err := config.SetforTesting("entra.primary_domain", "testIntegration.com"); err != nil {
+		t.Fatal(err)
+	}
+
 	creator := types.User{
-		Username: "bob@example.com",
+		Username: "bob@testIntegration.com",
 	}
 	assert.NoError(t, db.Create(&creator).Error)
 
 	signatoryUser := types.User{
-		Username: "user1@",
+		Username: "user1@testIntegration.com",
 	}
 	assert.NoError(t, db.Create(&signatoryUser).Error)
 
@@ -140,7 +147,7 @@ func TestIntegration_ValidateContract(t *testing.T) {
 
 	validBase := openapi.ContractBase{
 		Title:                 "Valid Contract",
-		OrganisationSignatory: "user1@",
+		OrganisationSignatory: "user1@testIntegration.com",
 		ThirdPartyName:        ptr("Third Party"),
 		Status:                openapi.ContractBaseStatusProposed,
 		StartDate:             ptr(now.Format("2006-01-02")),
@@ -279,14 +286,20 @@ func TestIntegration_CreateContract(t *testing.T) {
 		s3:    mockS3,
 	}
 
+	// set up test config
+	config.Init()
+	if err := config.SetforTesting("entra.primary_domain", "testIntegration.com"); err != nil {
+		t.Fatal(err)
+	}
+
 	// set up required models
 	creator := types.User{
-		Username: "bob@example.com",
+		Username: "bob@testIntegration.com",
 	}
 	assert.NoError(t, db.Create(&creator).Error)
 
 	signatoryUser := types.User{
-		Username: "user1@",
+		Username: "user1@testIntegration.com",
 	}
 	assert.NoError(t, db.Create(&signatoryUser).Error)
 
@@ -305,7 +318,7 @@ func TestIntegration_CreateContract(t *testing.T) {
 
 	contractBase := openapi.ContractBase{
 		Title:                 "Integration Contract",
-		OrganisationSignatory: "user1@",
+		OrganisationSignatory: "user1@testIntegration.com",
 		ThirdPartyName:        ptr("Third Party"),
 		Status:                openapi.ContractBaseStatusProposed,
 		StartDate:             ptr("2024-01-01"),

--- a/internal/service/studies/main.go
+++ b/internal/service/studies/main.go
@@ -28,8 +28,8 @@ const (
 type Service struct {
 	db    *gorm.DB
 	entra entra.Interface
-	s3    *s3.Controller
-	users *users.Service
+	s3    s3.Interface
+	users users.Interface
 }
 
 func New() *Service {

--- a/internal/service/users/interface.go
+++ b/internal/service/users/interface.go
@@ -1,0 +1,40 @@
+package users
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	openapi "github.com/ucl-arc-tre/portal/internal/openapi/web"
+	"github.com/ucl-arc-tre/portal/internal/types"
+)
+
+type Interface interface {
+	ConfirmAgreement(user types.User, agreementId uuid.UUID) error
+	ConfirmedAgreements(user types.User) ([]openapi.ConfirmedAgreement, error)
+	Attributes(user types.User) (types.UserAttributes, error)
+	SetUserChosenName(user types.User, chosenName types.ChosenName) error
+	ImportApprovedResearchersCSV(
+		ctx context.Context,
+		importer types.User,
+		csvContent []byte,
+		agreement types.Agreement,
+	) error
+	InviteExternalUser(ctx context.Context, email string, inviter types.User) (types.User, error)
+	CreateUserSponsorship(user types.User, sponsor types.User) (types.UserSponsorship, error)
+	Metrics() (*openapi.UserMetrics, error)
+	UpdateTraining(user types.User, data openapi.ProfileTrainingUpdate) (openapi.ProfileTrainingResponse, error)
+	CreateNHSDTrainingRecord(user types.User, completedAt time.Time) error
+	TrainingRecords(user types.User) ([]openapi.TrainingRecord, error)
+	NHSDTrainingExpiresAt(user types.User) (*time.Time, error)
+	//func NHSDTrainingIsValid(completedAt time.Time) bool
+	PersistedUser(username types.Username) (types.User, error)
+	PersistedExternalUser(username types.Username, email Email) (types.User, error)
+	UserExistsWithEmailOrUsername(ctx context.Context, value string) (bool, error)
+	IsStaff(ctx context.Context, user types.User) (bool, error)
+	UserById(id uuid.UUID) (*types.User, error)
+	UserByUsername(username types.Username) (*types.User, error)
+	UserIds(usernames ...types.Username) (map[types.Username]uuid.UUID, error)
+	Find(ctx context.Context, query string) ([]openapi.UserData, error)
+	AllApprovedResearchers() ([]ApprovedResearcherExportRecord, error)
+}

--- a/internal/service/users/interface.go
+++ b/internal/service/users/interface.go
@@ -27,7 +27,6 @@ type Interface interface {
 	CreateNHSDTrainingRecord(user types.User, completedAt time.Time) error
 	TrainingRecords(user types.User) ([]openapi.TrainingRecord, error)
 	NHSDTrainingExpiresAt(user types.User) (*time.Time, error)
-	//func NHSDTrainingIsValid(completedAt time.Time) bool
 	PersistedUser(username types.Username) (types.User, error)
 	PersistedExternalUser(username types.Username, email Email) (types.User, error)
 	UserExistsWithEmailOrUsername(ctx context.Context, value string) (bool, error)

--- a/internal/service/users/main.go
+++ b/internal/service/users/main.go
@@ -8,7 +8,7 @@ import (
 
 type Service struct {
 	db    *gorm.DB
-	entra *entra.Controller
+	entra entra.Interface
 }
 
 func New() *Service {

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -3,13 +3,17 @@ package testutil
 import (
 	"fmt"
 	"os"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
+
+var setupOnce sync.Once
 
 type Migrator func(*gorm.DB) error
 
@@ -30,12 +34,30 @@ func NewTestDBSchema(t *testing.T, migrate Migrator) *gorm.DB {
 	adminDB, err := gorm.Open(postgres.Open(baseDSN), &gorm.Config{})
 	require.NoError(err, "admin connect")
 
+	// run a one-time bootstrap step for creating extension & sequence;
+	// make sure the extension & sequence are created before creating the schema
+	setupOnce.Do(func() {
+		fmt.Printf("adminDB bootstrap (extension + sequence)\n")
+
+		connectRetryDelay := 1 * time.Second
+
+		for {
+			err1 := adminDB.Exec(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`).Error
+			err2 := adminDB.Exec(`CREATE SEQUENCE IF NOT EXISTS study_caseref_seq START 10000;`).Error
+			if err1 == nil && err2 == nil {
+				return
+			}
+			time.Sleep(connectRetryDelay)
+			connectRetryDelay *= 2
+		}
+	})
+
 	// Create schema
 	err = adminDB.Exec(fmt.Sprintf(`CREATE SCHEMA "%s"`, schema)).Error
 	require.NoError(err, "create schema")
 
 	// Connect with search_path
-	dsn := fmt.Sprintf("%s search_path=%s", baseDSN, schema)
+	dsn := fmt.Sprintf("%s search_path=%s,public", baseDSN, schema)
 
 	testDB, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	require.NoError(err, "connect test db")

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -39,9 +40,18 @@ func NewTestDBSchema(t *testing.T, migrate Migrator) *gorm.DB {
 	setupOnce.Do(func() {
 		fmt.Printf("adminDB bootstrap (extension + sequence)\n")
 
+		// use a 10-min timeout to prevent CI jobs end up hanging
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+
 		connectRetryDelay := 1 * time.Second
 
 		for {
+			select {
+			case <-ctx.Done():
+				panic(fmt.Sprintf("adminDB bootstrap failed after timeout: %v", ctx.Err()))
+			default:
+			}
 			err1 := adminDB.Exec(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`).Error
 			err2 := adminDB.Exec(`CREATE SEQUENCE IF NOT EXISTS study_caseref_seq START 10000;`).Error
 			if err1 == nil && err2 == nil {

--- a/internal/testutil/entra.go
+++ b/internal/testutil/entra.go
@@ -3,46 +3,49 @@ package testutil
 import (
 	"context"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/ucl-arc-tre/portal/internal/controller/entra"
 	openapi "github.com/ucl-arc-tre/portal/internal/openapi/web"
 	"github.com/ucl-arc-tre/portal/internal/types"
 )
 
-type FakeEntra struct {
+type MockEntra struct {
+	mock.Mock
 }
 
-func (f *FakeEntra) IsStaffMember(ctx context.Context, username types.Username) (bool, error) {
+func (f *MockEntra) IsStaffMember(ctx context.Context, username types.Username) (bool, error) {
 	panic("not implemented")
 }
 
-func (f *FakeEntra) UserExists(ctx context.Context, username types.Username) (bool, error) {
+func (f *MockEntra) UserExists(ctx context.Context, username types.Username) (bool, error) {
 	panic("not implemented")
 }
 
-func (f *FakeEntra) SendInvite(ctx context.Context, email string, sponsor types.Sponsor) (*entra.InvitedUserData, error) {
+func (f *MockEntra) SendInvite(ctx context.Context, email string, sponsor types.Sponsor) (*entra.InvitedUserData, error) {
 	panic("not implemented")
 }
 
-func (f *FakeEntra) AddtoInvitedUserGroup(ctx context.Context, user entra.InvitedUserData) error {
+func (f *MockEntra) AddtoInvitedUserGroup(ctx context.Context, user entra.InvitedUserData) error {
 	panic("not implemented")
 }
 
-func (f *FakeEntra) FindUsernames(ctx context.Context, query string) ([]types.Username, error) {
+func (f *MockEntra) FindUsernames(ctx context.Context, query string) ([]types.Username, error) {
+	args := f.Called(ctx, query)
+	return args.Get(0).([]types.Username), args.Error(1)
+}
+
+func (f *MockEntra) SendCustomInviteNotification(ctx context.Context, email string, sponsor types.Sponsor) error {
 	panic("not implemented")
 }
 
-func (f *FakeEntra) SendCustomInviteNotification(ctx context.Context, email string, sponsor types.Sponsor) error {
+func (f *MockEntra) SendContractExpiryNotification(ctx context.Context, emails []string, contract types.Contract, study types.Study) error {
 	panic("not implemented")
 }
 
-func (f *FakeEntra) SendContractExpiryNotification(ctx context.Context, emails []string, contract types.Contract, study types.Study) error {
+func (f *MockEntra) SendTrainingExpiryNotification(ctx context.Context, email string, training types.UserTrainingRecord) error {
 	panic("not implemented")
 }
 
-func (f *FakeEntra) SendTrainingExpiryNotification(ctx context.Context, email string, training types.UserTrainingRecord) error {
-	panic("not implemented")
-}
-
-func (f *FakeEntra) SendCustomStudyReviewNotification(ctx context.Context, emails []string, review openapi.StudyReview) error {
+func (f *MockEntra) SendCustomStudyReviewNotification(ctx context.Context, emails []string, review openapi.StudyReview) error {
 	panic("not implemented")
 }

--- a/internal/testutil/s3.go
+++ b/internal/testutil/s3.go
@@ -1,0 +1,38 @@
+package testutil
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/ucl-arc-tre/portal/internal/controller/s3"
+	"github.com/ucl-arc-tre/portal/internal/types"
+)
+
+type MockS3 struct {
+	mock.Mock
+}
+
+func (m *MockS3) StoreObject(ctx context.Context, metadata s3.ObjectMetadata, obj types.S3Object) error {
+	args := m.Called(ctx, metadata, obj)
+	return args.Error(0)
+}
+
+func (m *MockS3) GetObject(ctx context.Context, metadata s3.ObjectMetadata) (types.S3Object, error) {
+	panic("not implemented")
+}
+
+func (m *MockS3) DeleteObject(metadata s3.ObjectMetadata) error {
+	panic("not implemented")
+}
+
+func MockS3Object(data string) types.S3Object {
+	reader := io.NopCloser(bytes.NewBufferString(data))
+	size := int64(len(data))
+
+	return types.S3Object{
+		Content:  reader,
+		NumBytes: &size,
+	}
+}

--- a/internal/testutil/users.go
+++ b/internal/testutil/users.go
@@ -1,0 +1,107 @@
+package testutil
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	openapi "github.com/ucl-arc-tre/portal/internal/openapi/web"
+	"github.com/ucl-arc-tre/portal/internal/service/users"
+	"github.com/ucl-arc-tre/portal/internal/types"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockUsers struct {
+	mock.Mock
+}
+
+func (m *MockUsers) ConfirmAgreement(user types.User, agreementId uuid.UUID) error {
+	panic("not implemented")
+}
+
+func (m *MockUsers) ConfirmedAgreements(user types.User) ([]openapi.ConfirmedAgreement, error) {
+	panic("not implemented")
+}
+
+func (m *MockUsers) Attributes(user types.User) (types.UserAttributes, error) {
+	panic("not implemented")
+}
+
+func (m *MockUsers) SetUserChosenName(user types.User, chosenName types.ChosenName) error {
+	panic("not implemented")
+}
+
+func (m *MockUsers) ImportApprovedResearchersCSV(
+	ctx context.Context,
+	importer types.User,
+	csvContent []byte,
+	agreement types.Agreement,
+) error {
+	panic("not implemented")
+}
+
+func (m *MockUsers) InviteExternalUser(ctx context.Context, email string, inviter types.User) (types.User, error) {
+	panic("not implemented")
+}
+
+func (m *MockUsers) CreateUserSponsorship(user types.User, sponsor types.User) (types.UserSponsorship, error) {
+	panic("not implemented")
+}
+
+func (m *MockUsers) Metrics() (*openapi.UserMetrics, error) {
+	panic("not implemented")
+}
+
+func (m *MockUsers) UpdateTraining(user types.User, data openapi.ProfileTrainingUpdate) (openapi.ProfileTrainingResponse, error) {
+	panic("not implemented")
+}
+
+func (m *MockUsers) CreateNHSDTrainingRecord(user types.User, completedAt time.Time) error {
+	panic("not implemented")
+}
+
+func (m *MockUsers) TrainingRecords(user types.User) ([]openapi.TrainingRecord, error) {
+	panic("not implemented")
+}
+
+func (m *MockUsers) NHSDTrainingExpiresAt(user types.User) (*time.Time, error) {
+	panic("not implemented")
+}
+
+func (m *MockUsers) PersistedUser(username types.Username) (types.User, error) {
+	args := m.Called(username)
+	return args.Get(0).(types.User), args.Error(1)
+}
+
+func (m *MockUsers) PersistedExternalUser(username types.Username, email users.Email) (types.User, error) {
+	panic("not implemented")
+}
+
+func (m *MockUsers) UserExistsWithEmailOrUsername(ctx context.Context, value string) (bool, error) {
+	panic("not implemented")
+}
+
+func (m *MockUsers) IsStaff(ctx context.Context, user types.User) (bool, error) {
+	panic("not implemented")
+}
+
+func (m *MockUsers) UserById(id uuid.UUID) (*types.User, error) {
+	panic("not implemented")
+}
+
+func (m *MockUsers) UserByUsername(username types.Username) (*types.User, error) {
+	panic("not implemented")
+}
+
+func (m *MockUsers) UserIds(usernames ...types.Username) (map[types.Username]uuid.UUID, error) {
+	panic("not implemented")
+}
+
+func (m *MockUsers) Find(ctx context.Context, query string) ([]openapi.UserData, error) {
+	panic("not implemented")
+}
+
+func (m *MockUsers) AllApprovedResearchers() ([]users.ApprovedResearcherExportRecord, error) {
+	panic("not implemented")
+}


### PR DESCRIPTION

## Works towards #577

This PR introduces interfaces for the `s3` controller and the `users` service, adds mocks `MockS3` and `MockUsers` for use in integration tests, and includes new tests for contract-related functionality in the studies service.
- Added `s3.Interface` in `/internal/controller/s3/interface.go`
- Added `users.Interface` in `/internal/service/users/interface.go`
- Added `MockS3` in `/internal/testutil/s3.go`
- Added `MockUsers` in `/internal/testutil/users.go`
- Added integration tests in `/internal/service/studies/integration_test.go`:
   - `TestIntegration_ValidateContract`: integration test for validating contracts
   - `TestIntegration_CreateContract`: integration test for `CreateContract`, `CreateContractObject`, and `GetContract`
- Renamed `FakeEntra` to `MockEntra` in `/internal/testutil/entra.go` for naming consistency
- Updated `NewTestDBSchema` in `/internal/testutil/db.go` to:
   - Run a one-time bootstrap step to create the uuid extension and sequence
   - Ensure these are created before the schema

### Checklist

- [ ] Documentation has been updated
