### PR TITLE
Add API users to TRE project form

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Management portal for [UCL ARC](https://www.ucl.ac.uk/advanced-research-computing/) services.
 
-The Service Portal aims to serve as a single entry point for researchers and other users to manage and engage with the various services and platforms supported by ARC, e.g. [TRE](https://www.ucl.ac.uk/advanced-research-computing/sensitive-data-and-trusted-research-environments), [DSH](https://www.ucl.ac.uk/isd/services/file-storage-sharing/data-safe-haven-dsh).
+The Service Portal aims to serve as a single entry point for researchers and other users to manage
+and engage with the various services and platforms supported by ARC, e.g.
+[TRE](https://www.ucl.ac.uk/advanced-research-computing/sensitive-data-and-trusted-research-environments),
+[DSH](https://www.ucl.ac.uk/isd/services/file-storage-sharing/data-safe-haven-dsh).
 
 Currently, the entities within the portal have the following relationships:
 
@@ -13,31 +16,42 @@ Currently, the entities within the portal have the following relationships:
 # Local development
 
 1. Fork this repository and create a branch, or Clone it if you're on the project team.
-2. Install [pre-commit](https://pre-commit.com/) (e.g. `pip install pre-commit` or `brew install pre-commit`), then run `pre-commit install` to set up the git hooks.
-3. Install the prerequisites: [node](https://nodejs.org/en/download), [go](https://go.dev/doc/install) and [oapi-codegen](https://github.com/oapi-codegen/oapi-codegen). Then run `cd web && npm install`.
+2. Install [pre-commit](https://pre-commit.com/) (e.g. `pip install pre-commit` or
+   `brew install pre-commit`), then run `pre-commit install` to set up the git hooks.
+3. Install the prerequisites: [node](https://nodejs.org/en/download),
+   [go](https://go.dev/doc/install) and
+   [oapi-codegen](https://github.com/oapi-codegen/oapi-codegen). Then run `cd web && npm install`.
 4. Install [Docker](https://docs.docker.com/get-started/get-docker/).
-5. Create `deploy/dev/oauth2-proxy.cfg` from [deploy/dev/oauth2-proxy.sample.cfg](./deploy/dev/oauth2-proxy.sample.cfg).
-6. Create `deploy/dev/config.yaml` from [deploy/dev/config.sample.yaml](./deploy/dev/config.sample.yaml).
+5. Create `deploy/dev/oauth2-proxy.cfg` from
+   [deploy/dev/oauth2-proxy.sample.cfg](./deploy/dev/oauth2-proxy.sample.cfg).
+6. Create `deploy/dev/config.yaml` from
+   [deploy/dev/config.sample.yaml](./deploy/dev/config.sample.yaml).
 7. Spin up a development environment by running `make dev`.
 
-Then go to http://localhost:8000. To destroy it run `make dev-destroy`. To see other commands run `make help`.
+Then go to <http://localhost:8000>. To destroy it run `make dev-destroy`. To see other commands run
+`make help`.
 
 Modify, commit, push and open a pull request against `main` for review.
 
-Note that you will need entra credentials to allow logging in to the portal as different users. Speak to a senior member of the team to set these up.
+Note that you will need entra credentials to allow logging in to the portal as different users.
+Speak to a senior member of the team to set these up.
 
 # Deployment
 
 ## Staging
 
-[Staging](https://portal.ucl-arc.dev/) is deployed automatically approximately 1 hour after merging into `main`.
+[Staging](https://portal.ucl-arc.dev/) is deployed automatically approximately 1 hour after merging
+into `main`.
 
 ## Production
 
-[Production](https://portal.arc.ucl.ac.uk) is deployed manually by a senior member of the team. This is done by updating the portal version in a separate deployment repository to the desired commit. Production deployments are done at the team's discretion — typically once a set of changes has been verified on staging.
+[Production](https://portal.arc.ucl.ac.uk) is deployed manually by a senior member of the team. This
+is done by updating the portal version in a separate deployment repository to the desired commit.
+Production deployments are done at the team's discretion — typically once a set of changes has been
+verified on staging.
 
 For more information on production deployments, refer to the project Slack channel docs.
 
 # Contact
 
-If you are part of a service team, check our [services documentation](docs/services.md). Otherwise, get in touch with [the portal team](mailto:arc.portal@ucl.ac.uk).
+Get in touch with [the portal team](mailto:arc.portal@ucl.ac.uk).

--- a/api/web.yaml
+++ b/api/web.yaml
@@ -2028,6 +2028,7 @@ components:
         - egress_requester
         - egress_checker
         - trusted_egresser
+        - api_user
 
     Environment:
       type: object

--- a/api/web.yaml
+++ b/api/web.yaml
@@ -2028,7 +2028,7 @@ components:
         - egress_requester
         - egress_checker
         - trusted_egresser
-        - api_user
+        - API_user
 
     Environment:
       type: object

--- a/internal/openapi/web/main.gen.go
+++ b/internal/openapi/web/main.gen.go
@@ -533,7 +533,7 @@ func (e EnvironmentName) Valid() bool {
 
 // Defines values for ProjectTRERoleName.
 const (
-	ApiUser         ProjectTRERoleName = "api_user"
+	APIUser         ProjectTRERoleName = "API_user"
 	DesktopUser     ProjectTRERoleName = "desktop_user"
 	EgressChecker   ProjectTRERoleName = "egress_checker"
 	EgressRequester ProjectTRERoleName = "egress_requester"
@@ -545,7 +545,7 @@ const (
 // Valid indicates whether the value is a known member of the ProjectTRERoleName enum.
 func (e ProjectTRERoleName) Valid() bool {
 	switch e {
-	case ApiUser:
+	case APIUser:
 		return true
 	case DesktopUser:
 		return true

--- a/internal/openapi/web/main.gen.go
+++ b/internal/openapi/web/main.gen.go
@@ -533,6 +533,7 @@ func (e EnvironmentName) Valid() bool {
 
 // Defines values for ProjectTRERoleName.
 const (
+	ApiUser         ProjectTRERoleName = "api_user"
 	DesktopUser     ProjectTRERoleName = "desktop_user"
 	EgressChecker   ProjectTRERoleName = "egress_checker"
 	EgressRequester ProjectTRERoleName = "egress_requester"
@@ -544,6 +545,8 @@ const (
 // Valid indicates whether the value is a known member of the ProjectTRERoleName enum.
 func (e ProjectTRERoleName) Valid() bool {
 	switch e {
+	case ApiUser:
+		return true
 	case DesktopUser:
 		return true
 	case EgressChecker:

--- a/internal/service/projects/integration_test.go
+++ b/internal/service/projects/integration_test.go
@@ -23,7 +23,6 @@ import (
 // To be called by each test within this package to AutoMigrate
 // only the models/tables required by this package
 func migrate(db *gorm.DB) error {
-
 	// Run migrations, only the models/tables required by this package
 	err := db.AutoMigrate(
 		&types.User{},
@@ -126,6 +125,7 @@ func TestCreateProjectTRE(t *testing.T) {
 				Roles: []openapi.ProjectTRERoleName{
 					openapi.DesktopUser,
 					openapi.Ingresser,
+					openapi.ApiUser,
 				},
 			},
 		},

--- a/internal/service/projects/integration_test.go
+++ b/internal/service/projects/integration_test.go
@@ -125,7 +125,7 @@ func TestCreateProjectTRE(t *testing.T) {
 				Roles: []openapi.ProjectTRERoleName{
 					openapi.DesktopUser,
 					openapi.Ingresser,
-					openapi.ApiUser,
+					openapi.APIUser,
 				},
 			},
 		},

--- a/internal/types/projects.go
+++ b/internal/types/projects.go
@@ -51,6 +51,7 @@ const (
 	ProjectTREEgressRequester ProjectTRERoleName = "egress_requester" // can request data to be egressed
 	ProjectTREEgressChecker   ProjectTRERoleName = "egress_checker"   // can approve egress requests
 	ProjectTRETrustedEgresser ProjectTRERoleName = "trusted_egresser" // can download data from the TRE without approval
+	ProjectTREAPIUser         ProjectTRERoleName = "api_user"         // can upload data through the TRE API
 )
 
 var AllProjectTRERoles = []ProjectTRERoleName{
@@ -60,6 +61,7 @@ var AllProjectTRERoles = []ProjectTRERoleName{
 	ProjectTREEgressRequester,
 	ProjectTREEgressChecker,
 	ProjectTRETrustedEgresser,
+	ProjectTREAPIUser,
 }
 
 type ProjectTRERoleBinding struct {

--- a/internal/types/projects.go
+++ b/internal/types/projects.go
@@ -51,7 +51,7 @@ const (
 	ProjectTREEgressRequester ProjectTRERoleName = "egress_requester" // can request data to be egressed
 	ProjectTREEgressChecker   ProjectTRERoleName = "egress_checker"   // can approve egress requests
 	ProjectTRETrustedEgresser ProjectTRERoleName = "trusted_egresser" // can download data from the TRE without approval
-	ProjectTREAPIUser         ProjectTRERoleName = "api_user"         // can upload data through the TRE API
+	ProjectTREAPIUser         ProjectTRERoleName = "API_user"         // can upload data through the TRE API
 )
 
 var AllProjectTRERoles = []ProjectTRERoleName{

--- a/web/src/components/profile/ProfileSetupSteps.tsx
+++ b/web/src/components/profile/ProfileSetupSteps.tsx
@@ -35,7 +35,7 @@ export default function ProfileSetupSteps({ profileData, agreementsData, trainin
     {
       id: "chosen-name",
       title: "Set Your Name",
-      description: "Enter your preferred name - this must match the name on your training certificate",
+      description: "Enter your full name - this must match the name on your training certificate",
       completed: hasChosenName,
       current: !hasChosenName,
     },

--- a/web/src/components/projects/tre/ProjectFormTRE.tsx
+++ b/web/src/components/projects/tre/ProjectFormTRE.tsx
@@ -38,7 +38,7 @@ const roles: Record<ProjectTreRoleName, Role> = {
   },
   trusted_egresser: {
     label: "Trusted Egresser",
-    description: "Can download data from the TRE environment without requiring approval",
+    description: "Can download data from the TRE environment to a trusted destination",
   },
   api_user: {
     label: "API User",

--- a/web/src/components/projects/tre/ProjectFormTRE.tsx
+++ b/web/src/components/projects/tre/ProjectFormTRE.tsx
@@ -6,45 +6,10 @@ import Button from "@/components/ui/Button";
 import { ProjectTre, ProjectTreRoleName } from "@/openapi";
 import styles from "./ProjectFormTRE.module.css";
 import RadioOptions from "@/components/ui/form/RadioOptions";
+import { Role, roles } from "./roles";
 
 // this should match the domain that is used for the entra ID users in the portal
 const domainName = process.env.NEXT_PUBLIC_DOMAIN_NAME || "@ucl.ac.uk";
-
-type Role = {
-  label: string;
-  description: string;
-};
-
-const roles: Record<ProjectTreRoleName, Role> = {
-  desktop_user: {
-    label: "Desktop User",
-    description: "Can access the desktop environment and work with data within the TRE",
-  },
-  ingresser: {
-    label: "Ingresser",
-    description: "Can upload data into the TRE environment",
-  },
-  egresser: {
-    label: "Egresser",
-    description: "Can download data from the TRE environment after approval",
-  },
-  egress_requester: {
-    label: "Egress Requester",
-    description: "Can request data to be downloaded from the TRE",
-  },
-  egress_checker: {
-    label: "Egress Checker",
-    description: "Can review and approve egress requests from other users",
-  },
-  trusted_egresser: {
-    label: "Trusted Egresser",
-    description: "Can download data from the TRE environment to a trusted destination",
-  },
-  api_user: {
-    label: "API User",
-    description: "Can use the TRE API to programmatically upload data into the TRE environment",
-  },
-};
 
 type Props = {
   fieldsDisabled: boolean;
@@ -75,9 +40,7 @@ export default function ProjectFormTREStep(props: Props) {
 
   const numRequiredEgressApprovals = watch("tre.numRequiredEgressApprovals");
   const members = watch("members");
-  console.log(members);
   const numEgressCheckers = members.filter((member) => member.roles.includes("egress_checker")).length;
-  console.log(numEgressCheckers, numRequiredEgressApprovals);
 
   return (
     <>

--- a/web/src/components/projects/tre/ProjectFormTRE.tsx
+++ b/web/src/components/projects/tre/ProjectFormTRE.tsx
@@ -40,6 +40,10 @@ const roles: Record<ProjectTreRoleName, Role> = {
     label: "Trusted Egresser",
     description: "Can download data from the TRE environment without requiring approval",
   },
+  api_user: {
+    label: "API User",
+    description: "Can use the TRE API to programmatically upload data into the TRE environment",
+  },
 };
 
 type Props = {

--- a/web/src/components/projects/tre/roles.ts
+++ b/web/src/components/projects/tre/roles.ts
@@ -1,0 +1,43 @@
+import { ProjectTreRoleName } from "@/openapi";
+
+export type Role = {
+  label: string;
+  description: string;
+};
+
+export const roles: Record<ProjectTreRoleName, Role> = {
+  desktop_user: {
+    label: "Desktop User",
+    description: "Can access the desktop environment and work with data within the TRE",
+  },
+  ingresser: {
+    label: "Ingresser",
+    description: "Can upload data into the TRE environment",
+  },
+  egresser: {
+    label: "Egresser",
+    description: "Can download data from the TRE environment after approval",
+  },
+  egress_requester: {
+    label: "Egress Requester",
+    description: "Can request data to be downloaded from the TRE",
+  },
+  egress_checker: {
+    label: "Egress Checker",
+    description: "Can review and approve egress requests from other users",
+  },
+  trusted_egresser: {
+    label: "Trusted Egresser",
+    description: "Can download data from the TRE environment to a trusted destination",
+  },
+  API_user: {
+    label: "API User",
+    description: "Can use the TRE API to programmatically upload data into the TRE environment",
+  },
+};
+
+// Returns a human-readable label for a TRE project role, falling back to a
+// de-underscored version of the raw role name for unknown roles.
+export function roleLabel(role: string): string {
+  return roles[role as ProjectTreRoleName]?.label ?? role.replace(/_/g, " ");
+}

--- a/web/src/openapi/types.gen.ts
+++ b/web/src/openapi/types.gen.ts
@@ -533,7 +533,7 @@ export type ProjectTreMember = {
 /**
  * Available TRE project roles
  */
-export type ProjectTreRoleName = 'desktop_user' | 'ingresser' | 'egresser' | 'egress_requester' | 'egress_checker' | 'trusted_egresser';
+export type ProjectTreRoleName = 'desktop_user' | 'ingresser' | 'egresser' | 'egress_requester' | 'egress_checker' | 'trusted_egresser' | 'api_user';
 
 /**
  * An environment with its tier mapping

--- a/web/src/openapi/types.gen.ts
+++ b/web/src/openapi/types.gen.ts
@@ -533,7 +533,7 @@ export type ProjectTreMember = {
 /**
  * Available TRE project roles
  */
-export type ProjectTreRoleName = 'desktop_user' | 'ingresser' | 'egresser' | 'egress_requester' | 'egress_checker' | 'trusted_egresser' | 'api_user';
+export type ProjectTreRoleName = 'desktop_user' | 'ingresser' | 'egresser' | 'egress_requester' | 'egress_checker' | 'trusted_egresser' | 'API_user';
 
 /**
  * An environment with its tier mapping

--- a/web/src/pages/projects/manage.tsx
+++ b/web/src/pages/projects/manage.tsx
@@ -17,6 +17,7 @@ import LoginFallback from "@/components/ui/LoginFallback";
 import Loading from "@/components/ui/Loading";
 import Button from "@/components/ui/Button";
 import ProjectForm from "@/components/projects/ProjectForm";
+import { roleLabel } from "@/components/projects/tre/roles";
 
 import styles from "./ManageProject.module.css";
 import Box from "@/components/ui/Box";
@@ -347,7 +348,7 @@ export default function ManageProjectPage() {
                     <div className={styles["member-roles"]}>
                       {member.roles.map((role, roleIndex) => (
                         <span key={roleIndex} className={styles["role-badge"]}>
-                          {role.replace(/_/g, " ")}
+                          {roleLabel(role)}
                         </span>
                       ))}
                     </div>


### PR DESCRIPTION
## Resolves #749

- Add API user as TRE role
- drive-by:
	- fix `trusted_egresser` description
	- change `preferred` name to `full name` to avoid [confusion](https://myservices-arc.uk.4me.com/requests/3058928)

### Checklist

- [x] Documentation has been updated
